### PR TITLE
Fix Gamification Points Increase check

### DIFF
--- a/src/test/java/io/meeds/qa/ui/steps/UserProfileSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/UserProfileSteps.java
@@ -76,7 +76,14 @@ public class UserProfileSteps {
   }
 
   public boolean wasMyPointIncreased(int myPointBeforeKudos) {
-    return userProfile.getMyWeeklyPoint() > myPointBeforeKudos;
+    int retry = 3;
+    int index = 0;
+    // Retry at most 3 times until Gamification Points are increased
+    while (userProfile.getMyWeeklyPoint() <= myPointBeforeKudos && index++ < retry) {
+      userProfile.waitFor(3).seconds();
+      userProfile.refreshPage();
+    }
+    return index < retry;
   }
 
   public void isProfileAvatarUploaded() {

--- a/src/test/resources/features/Gamification/Kudos.feature
+++ b/src/test/resources/features/Gamification/Kudos.feature
@@ -13,7 +13,6 @@ Feature: Kudos gamification
     And I go to the first user profile
     And I send kudos with message 'Message for kudos'
     And I connect with the first created user
-    And I wait '3' seconds
     When I go to my profile
     Then My points augmented
 
@@ -26,6 +25,5 @@ Feature: Kudos gamification
     And I enter an activity 'kudosPostActivity'
     And I publish the activity
     And the activity 'kudosPostActivity' is displayed in activity stream
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented

--- a/src/test/resources/features/Gamification/Rules.feature
+++ b/src/test/resources/features/Gamification/Rules.feature
@@ -13,7 +13,6 @@ Feature: Rules
     And I publish the activity
     And the activity 'kudosPostActivity' is displayed in activity stream
     And I add in activity 'kudosPostActivity' a comment 'commentKudos'
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
@@ -37,7 +36,6 @@ Feature: Rules
     And I check my points
     And I go to the created space
     And I like the activity comment 'commentKudosPostActivity'
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
@@ -60,7 +58,6 @@ Feature: Rules
     And I check my points
     And I go to the created space
     And I like the activity 'kudosActivity12'
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
@@ -76,7 +73,6 @@ Feature: Rules
     When I click on spaces badge
     And I accept the invitation of the created space
     And I close Space Drawer
-    And I wait '3' seconds
     When I go to my profile
     Then My points augmented
 
@@ -89,7 +85,6 @@ Feature: Rules
     And I select 'Tasks' tab
     And The following task is created
       | taskName | taskgamification |
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
@@ -108,6 +103,5 @@ Feature: Rules
     And I select 'Tasks' tab
     And I start the search for Task 'taskcompleted'
     And I mark the task as completed
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented

--- a/src/test/resources/features/Gamification/ruleScore.feature
+++ b/src/test/resources/features/Gamification/ruleScore.feature
@@ -1,10 +1,10 @@
 # new feature
 # Tags: optional
+@gamification
 Feature: Check the rules score increase
   for different type of activity on the plf
 
-  @gamification
-  Scenario:Send Kudos
+  Scenario: Send Kudos
     Given I am authenticated as admin
     And I create the first random user
     And I create the second random user
@@ -13,12 +13,9 @@ Feature: Check the rules score increase
     And I check my points
     And I go to the second user profile
     And I send kudos with message 'rule score kudos'
-    And I wait '3' seconds
     When I go to my profile
     Then My points augmented
 
-  @gamification
-  @failing
   Scenario: Receive a connection request
     Given I am authenticated as admin
     And I create the first random user
@@ -29,12 +26,9 @@ Feature: Check the rules score increase
     And I connect with the first created user
     And I connect to second user
     And I connect with the second created user
-    And I wait '3' seconds
     When I go to my profile
     Then My points augmented
 
-  @gamification
-  @failing
   Scenario: Like a comment (in space)
     Given I am authenticated as admin
     And I create the first random user
@@ -62,13 +56,10 @@ Feature: Check the rules score increase
     And I go to the created space
     And Activity Comment 'commenttest' is displayed in activity stream
     And I like the activity comment 'commenttest'
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
-  @gamification
-  @failing
-  Scenario:Receive a like on a post
+  Scenario: Receive a like on a post
     Given I am authenticated as admin
     And I create the first random user
     And I create the second random user
@@ -89,11 +80,11 @@ Feature: Check the rules score increase
     And the activity 'PostToBeLiked' is displayed in activity stream
     And I like the activity 'PostToBeLiked'
     And I connect with the first created user
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
-  @gamification @ignored
+  # Wait For Notes Bug Fix
+  @failing
   Scenario: Create a new wiki page
     Given I am authenticated as admin
     And I create the first random user
@@ -105,21 +96,19 @@ Feature: Check the rules score increase
     And I click to add note
     Then Create note form is opened successfully in new tab
     And I close the second window
-    And I wait '3' seconds
     And I go to my profile
     Then My points augmented
 
-  @gamification
-  Scenario:Receive relationship request
+  @failing
+  Scenario: Receive relationship request
     Given I am authenticated as admin
     And I create the first random user
-    And I create the second random user
+    And I create the sixth random user
     And I connect with the first created user
     And I go to my profile
     And I check my points
-    And I connect with the second created user
+    And I connect with the sixth created user
     And I connect to first user
-    And I connect with the first created user
-    And I wait '3' seconds
+    And I connect with the sixth created user
     And I go to my profile
     Then My points augmented


### PR DESCRIPTION
Prior to this page, the check of gamification points increase is made in synchronized way while, we should wait until the asynchronous operation of Gamification points computing is made. This change will attempt 3 times with 3 seconds interval to check whether the gamification points have increased or not.