### PR TITLE
Fix CKEditor Text editing

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
+++ b/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
@@ -200,7 +200,6 @@ public class BasePageImpl extends PageObject implements BasePage {
     waitCKEditorLoading();
     retryOnCondition(() -> {
       ckEditorFrame.waitUntilVisible();
-      ckEditorFrame.clickOnElement();
       driver.switchTo().frame(ckEditorFrame);
     }, driver.switchTo()::defaultContent);
     try {

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/Notes/NotePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/Notes/NotePage.java
@@ -65,7 +65,6 @@ public class NotePage extends GenericPage {
   public void addNote(String noteTitle, String noteContent) {
     noteTileTextBox.setTextValue(noteTitle);
     ckEditorFrameNote.waitUntilVisible();
-    ckEditorFrameNote.clickOnElement();
     driver.switchTo().frame(ckEditorFrameNote);
     try {
       noteContentTextBox.waitUntilVisible();
@@ -128,7 +127,6 @@ public class NotePage extends GenericPage {
   public void createNotePage(String noteTitle, String noteContent) {
     noteTileTextBox.setTextValue(noteTitle);
     ckEditorFrameNote.waitUntilVisible();
-    ckEditorFrameNote.clickOnElement();
     driver.switchTo().frame(ckEditorFrameNote);
     try {
       noteContentTextBox.waitUntilVisible();
@@ -153,7 +151,6 @@ public class NotePage extends GenericPage {
   public void editNotePage(String noteTitleEdited, String noteContentEdited) {
     noteTileTextBox.setTextValue(noteTitleEdited);
     ckEditorFrameNote.waitUntilVisible();
-    ckEditorFrameNote.clickOnElement();
     driver.switchTo().frame(ckEditorFrameNote);
     try {
       noteContentTextBox.waitUntilVisible();

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/Social/SocialPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/Social/SocialPage.java
@@ -48,7 +48,7 @@ public class SocialPage extends GenericPage {
   @SwitchToWindow
   public void cancelUpdateActivityComment(String comment) {
     waitCKEditorLoading();
-    ckEditorFrameComment.clickOnElement();
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       commentField.waitUntilVisible();
@@ -104,7 +104,7 @@ public class SocialPage extends GenericPage {
   @SwitchToWindow
   public void updateActivityComment(String comment) {
     waitCKEditorLoading();
-    ckEditorFrameComment.clickOnElement();
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       commentField.waitUntilVisible();

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/engagement/ChallengesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/engagement/ChallengesPage.java
@@ -81,7 +81,7 @@ public class ChallengesPage extends GenericPage {
 
   @SwitchToWindow
   public void addAnnouncementWithRandomDescription(String announcementDescription) {
-    ckEditorFrameChallenge.clickOnElement();
+    ckEditorFrameChallenge.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameChallenge);
     try {
       challengeDescriptionField.waitUntilVisible();
@@ -96,7 +96,7 @@ public class ChallengesPage extends GenericPage {
   public void addChallengeWithDescription(String description) {
     waitCKEditorLoading();
     retryOnCondition(() -> {
-      clickOnElement(ckEditorFrameChallenge);
+      ckEditorFrameChallenge.waitUntilVisible();
       driver.switchTo().frame(ckEditorFrameChallenge);
     }, driver.switchTo()::defaultContent);
     try {
@@ -111,7 +111,6 @@ public class ChallengesPage extends GenericPage {
   @SwitchToWindow
   public void addChallengeWithRandomDescription(String challengeDescription) {
     ckEditorFrameChallenge.waitUntilVisible();
-    ckEditorFrameChallenge.clickOnElement();
     driver.switchTo().frame(ckEditorFrameChallenge);
     try {
       challengeDescriptionField.waitUntilVisible();

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/space/SpaceHomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/space/SpaceHomePage.java
@@ -214,16 +214,18 @@ public class SpaceHomePage extends GenericPage {
     waitCKEditorLoading();
 
     ckEditorFrame.waitUntilVisible();
-    ckEditorFrame.clickOnElement();
     driver.switchTo().frame(ckEditorFrame);
 
     try {
       if (activity.contains("https")) {
+        // A workaround to the fact that the preview isn't triggered only by a Paste Event
         activityContentTextBox.sendKeys(activity);
         activityContentTextBox.sendKeys(Keys.CONTROL + "a" + "x");
         driver.switchTo().defaultContent();
         closeActivityComposerDrawer();
         clickPostIcon();
+        waitForDrawerToOpen();
+        ckEditorFrame.waitUntilVisible();
         driver.switchTo().frame(ckEditorFrame);
         activityContentTextBox.sendKeys(Keys.CONTROL + "v");
         activityLinkPreview.waitUntilVisible();
@@ -245,7 +247,7 @@ public class SpaceHomePage extends GenericPage {
 
     getCommentElementLink(activityId).clickOnElement();
 
-    clickOnCommentRichText();
+    waitOnCommentRichText();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       ckEditorBodyComment.waitUntilVisible();
@@ -263,7 +265,7 @@ public class SpaceHomePage extends GenericPage {
     String activityId = getActivityId(activity);
     getCommentReply(comment, activityId).clickOnElement();
 
-    clickOnCommentRichText();
+    waitOnCommentRichText();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       ckEditorBodyComment.waitUntilVisible();
@@ -407,11 +409,9 @@ public class SpaceHomePage extends GenericPage {
     getCommentElementLink(activityId).clickOnElement();
   }
 
-  private void clickOnCommentRichText() {
+  private void waitOnCommentRichText() {
     waitCKEditorLoading();
-
     ckEditorFrameComment.waitUntilVisible();
-    ckEditorFrameComment.clickOnElement();
   }
 
   public void clickOnCommentsDrawerFirstPage() {
@@ -633,6 +633,7 @@ public class SpaceHomePage extends GenericPage {
 
   @SwitchToWindow
   public void enterActivityText(String activity) {
+    ckEditorFrame.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrame);
     try {
       activityContentTextBox.waitUntilVisible();
@@ -651,7 +652,7 @@ public class SpaceHomePage extends GenericPage {
 
     getCommentElementLink(activityId).clickOnElement();
 
-    clickOnCommentRichText();
+    waitOnCommentRichText();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       if (comment.contains("https")) {
@@ -660,7 +661,7 @@ public class SpaceHomePage extends GenericPage {
         driver.navigate().refresh();
         getCommentElementLink(activityId).clickOnElement();
         ckEditorFrameComment.waitUntilVisible();
-        clickOnCommentRichText();
+        waitOnCommentRichText();
         driver.switchTo().frame(ckEditorFrameComment);
 
         ckEditorBodyComment.waitUntilVisible();
@@ -682,6 +683,7 @@ public class SpaceHomePage extends GenericPage {
 
   @SwitchToWindow
   public void enterCommentText(String comment) {
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       ckEditorBodyComment.waitUntilVisible();
@@ -1175,6 +1177,7 @@ public class SpaceHomePage extends GenericPage {
 
   @SwitchToWindow
   public void updateCommentText(String comment) {
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
 
     try {
@@ -1189,6 +1192,7 @@ public class SpaceHomePage extends GenericPage {
 
   @SwitchToWindow
   public void userIsMentionedInCommentEntered(String user) {
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       assertWebElementVisible(getMentionedUserInCommentEntered(user));
@@ -1199,6 +1203,7 @@ public class SpaceHomePage extends GenericPage {
 
   @SwitchToWindow
   public void userIsNotMentionedInCommentEntered(String user) {
+    ckEditorFrameComment.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameComment);
     try {
       assertWebElementNotVisible(getMentionedUserInCommentEntered(user), 2);

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/tasks/TasksPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/tasks/TasksPage.java
@@ -520,7 +520,9 @@ public class TasksPage extends GenericPage {
   public void addProjectWithDescription(String projectName, String description) {
     addProjectOrTask.clickOnElement();
     projectTitle.setTextValue(projectName);
-    ckEditorFrameTask.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       projectDescriptionField.waitUntilVisible();
@@ -748,6 +750,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void checkUpdatedDescription(String Description) {
     taskDescriptionField.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameDescription.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameDescription);
     try {
       assertEquals(settaskDescription.getText(), Description);
@@ -1002,7 +1007,8 @@ public class TasksPage extends GenericPage {
 
   @SwitchToWindow
   public void commentTask(String comment) {
-    ckEditorFrameTask.clickOnElement();
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       taskCommentContentTextBox.waitUntilVisible();
@@ -1068,6 +1074,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void editDescriptionForTask(String newDescription) {
     taskDescriptionField.clickOnElement();
+
+    waitCKEditorLoading();
+    switchToFrameTaskUser.waitUntilVisible();
     driver.switchTo().frame(switchToFrameTaskUser);
     try {
       taskDescriptionBodyField.waitUntilVisible();
@@ -1097,7 +1106,9 @@ public class TasksPage extends GenericPage {
     projectThreeDotsButton.clickOnElement();
     editProjectButton.clickOnElement();
     projectTitle.setTextValue(newProjectName);
-    ckEditorFrameTask.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       projectDescriptionField.waitUntilVisible();
@@ -1121,6 +1132,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void enterDescriptionForTask(String description) {
     taskDescriptionField.clickOnElement();
+
+    waitCKEditorLoading();
+    switchToFrameTask.waitUntilVisible();
     driver.switchTo().frame(switchToFrameTask);
     try {
       taskDescriptionBodyField.waitUntilVisible();
@@ -1138,7 +1152,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void enterProjectDescriptionWithoutTheTitle(String description) {
     addProjectOrTask.clickOnElement();
-    ckEditorFrameTask.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       projectDescriptionField.waitUntilVisible();
@@ -1153,7 +1169,9 @@ public class TasksPage extends GenericPage {
   public void enterProjectTitleAndDescription(String projectName, String description) {
     addProjectOrTask.clickOnElement();
     projectTitle.setTextValue(projectName);
-    ckEditorFrameTask.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       projectDescriptionField.waitUntilVisible();
@@ -1170,7 +1188,8 @@ public class TasksPage extends GenericPage {
 
   @SwitchToWindow
   public void enterTaskComment(String comment) {
-    ckEditorFrameTask.clickOnElement();
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       taskCommentContentTextBox.waitUntilVisible();
@@ -1463,6 +1482,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void maxCharsNumberMessageIsDisplayed() {
     commentsDrawerSection.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameTask.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameTask);
     try {
       assertWebElementVisible(commentTaskMaxCharsMsg);
@@ -1603,6 +1625,9 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void setTaskDescription(String Description) {
     taskDescriptionField.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameDescription.waitUntilVisible();
     driver.switchTo().frame(ckEditorFrameDescription);
     try {
       settaskDescription.sendKeys(Description);
@@ -1727,8 +1752,11 @@ public class TasksPage extends GenericPage {
   @SwitchToWindow
   public void updateTaskDescription(String description) {
     taskDescriptionField.clickOnElement();
+
+    waitCKEditorLoading();
+    ckEditorFrameDescription.waitUntilVisible();
+    driver.switchTo().frame(ckEditorFrameDescription);
     try {
-      driver.switchTo().frame(ckEditorFrameDescription);
       settaskDescription.sendKeys(" " + description);
     } finally {
       driver.switchTo().defaultContent();


### PR DESCRIPTION
Prior to this change, the CKEditor IFrame was clicked before switching into it. With the recent changes of CKEditor toolbar, the CKEditor IFrame has become unclickable. Thus, before switching into its body to enter a new text, this change will wait until it's visible which is sufficient to enter text on CKEditor.