### PR TITLE
Fix US that is dependent from previously executed tests

### DIFF
--- a/src/test/resources/features/Tasks/Tasks.feature
+++ b/src/test/resources/features/Tasks/Tasks.feature
@@ -141,8 +141,7 @@ Feature: Tasks
     And I create the first random user if not existing
     And I connect with the first created user
 
-    And I go to the random space
-    And I refresh the page
+    And I create a random space
     And I go to Tasks in space tab
     And I create the project 'new project test'
     Then the project is created successfully and displayed on Tasks Space tab
@@ -169,7 +168,6 @@ Feature: Tasks
     And Project 'new project test' is displayed in Tasks App Center
     And Project 'second project test' is displayed in Tasks App Center
 
-  @test
   Scenario: Create Task with a new status
     Given I am authenticated as admin
     And I create the first random user if not existing


### PR DESCRIPTION
Prior tot his change, the US on Tasks attempts to connect with created random user who is admitted as administrator inside the random space which is a shared and reusable space through scenarios. This change will create a new space specifically for it where the first random user is supposed to be an adminstrator of the random space.