### PR TITLE
fix: Fix Random fail on Settings Page check for user notifications

### DIFF
--- a/src/main/java/io/meeds/qa/ui/elements/BaseElementFacadeImpl.java
+++ b/src/main/java/io/meeds/qa/ui/elements/BaseElementFacadeImpl.java
@@ -23,7 +23,6 @@ import net.serenitybdd.core.selectors.Selectors;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.util.EnvironmentVariables;
-import net.thucydides.core.webdriver.exceptions.ElementNotFoundAfterTimeoutError;
 import net.thucydides.core.webdriver.javascript.JavascriptExecutorFacade;
 
 public class BaseElementFacadeImpl extends WebElementFacadeImpl implements BaseElementFacade {

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/settings/SettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/settings/SettingsPage.java
@@ -9,6 +9,13 @@ import io.meeds.qa.ui.pages.GenericPage;
 import net.serenitybdd.core.annotations.findby.FindBy;
 
 public class SettingsPage extends GenericPage {
+
+  private static final String NOTIFICATION_SWITCH_BUTTON_XPATH          =
+                                                               "(//*[@id='UserSettingNotifications']//*[contains(@class, 'v-input--switch')]//input)[%s]";
+
+  private static final String NOTIFICATION_SWITCH_BUTTON_BY_STATE_XPATH = NOTIFICATION_SWITCH_BUTTON_XPATH
+      + "//self::*[@aria-checked='%s']//ancestor::*[contains(@class, 'v-input')]";
+
   @FindBy(
       xpath = "(//button[@class='btn btn-primary v-btn v-btn--contained theme--light v-size--default']//*[@class='v-btn__content'])[1]"
   )
@@ -190,43 +197,32 @@ public class SettingsPage extends GenericPage {
 
   public void checkThatNotificationOnMobileIsDisabled() {
     // Notification On Mobile is disabled
-    Assert.assertEquals(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[2]").getAttribute("aria-checked"),
-                        "false");
-
+    checkNotificationSwitchButtonState(2, false);
   }
 
   public void checkThatNotificationOnMobileIsEnabled() {
     // Notification On Mobile is enabled
-    Assert.assertEquals(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[2]").getAttribute("aria-checked"),
-                        "true");
-
+    checkNotificationSwitchButtonState(2, true);
   }
 
   public void checkThatNotificationOnSiteIsDisabled() {
     // Notification On Site is disabled
-    Assert.assertEquals(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[3]").getAttribute("aria-checked"),
-                        "false");
-
+    checkNotificationSwitchButtonState(3, false);
   }
 
   public void checkThatNotificationOnSiteIsEnabled() {
     // Notification On Site is enabled
-    Assert.assertEquals(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[3]").getAttribute("aria-checked"),
-                        "true");
-
+    checkNotificationSwitchButtonState(3, true);
   }
 
   public void checkThatNotificationViaMailIsDisabled() {
     // Notification Via Mail is disabled
-    Assert.assertTrue(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[1]").getAttribute("aria-checked")
-                                                                                                      .contains("false"));
+    checkNotificationSwitchButtonState(1, false);
   }
 
   public void checkThatNotificationViaMailIsEnabled() {
     // Notification Via Mail is enabled
-    Assert.assertEquals(findByXPathOrCSS("(//*[@class='v-input--selection-controls__input']//input)[1]").getAttribute("aria-checked"),
-                        "true");
-
+    checkNotificationSwitchButtonState(1, true);
   }
 
   public void checkThatPerkStoreSectionIsDisplayed() {
@@ -308,30 +304,16 @@ public class SettingsPage extends GenericPage {
     return findByXPathOrCSS(String.format("//*[contains(text(),'%s')]", timeZone));
   }
 
-  public void enableDisableGeneralNotificationsOnMobile() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[2]").clickOnElement();
-  }
-
-  public void enableDisableGeneralNotificationsOnSite() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[3]").clickOnElement();
-
-  }
-
-  public void enableDisableGeneralNotificationsViaMail() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[1]").clickOnElement();
-
-  }
-
   public void enableDisableNotificationOnMobile() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[2]").click();
+    clickOnNotificationSwitchButton(2);
   }
 
   public void enableDisableNotificationOnSite() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[3]").click();
+    clickOnNotificationSwitchButton(3);
   }
 
   public void enableDisableNotificationViaMail() {
-    findByXPathOrCSS("(//*[@class='v-input--selection-controls__input'])[1]").click();
+    clickOnNotificationSwitchButton(1);
   }
 
   public void generalNotificationsSendingMailTypeIsDaily() {
@@ -440,6 +422,24 @@ public class SettingsPage extends GenericPage {
   public void weeklyEmailIsDisplayedInGeneralNotificationsSection() {
     // Check that Weeky Email is displayed in General Notifications Section
     Assert.assertTrue(ELEMENT_GENERAL_NOTIFICATIONS_SECTION.getText().contains("Weekly digest email notification"));
+  }
+
+  private void clickOnNotificationSwitchButton(int switchButtonIndex) {
+    BaseElementFacade element = findByXPathOrCSS(String.format(NOTIFICATION_SWITCH_BUTTON_XPATH, String.valueOf(switchButtonIndex)));
+    boolean beforeClickState = Boolean.parseBoolean(element.getAttribute("aria-checked"));
+    element.findByXPath("//ancestor::*[contains(@class, 'v-input')]").clickOnElement();
+
+    boolean expectedNewState = !beforeClickState;
+    element = findByXPathOrCSS(String.format(NOTIFICATION_SWITCH_BUTTON_BY_STATE_XPATH,
+                                             String.valueOf(switchButtonIndex),
+                                             String.valueOf(expectedNewState)));
+    element.waitUntilVisible();
+  }
+
+  private void checkNotificationSwitchButtonState(int switchButtonIndex, boolean expectedState) {
+    assertWebElementVisible(findByXPathOrCSS(String.format(NOTIFICATION_SWITCH_BUTTON_BY_STATE_XPATH,
+                                                           String.valueOf(switchButtonIndex),
+                                                           String.valueOf(expectedState))));
   }
 
   public enum mailSendingType {

--- a/src/test/java/io/meeds/qa/ui/steps/SettingsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/SettingsSteps.java
@@ -156,21 +156,6 @@ public class SettingsSteps {
 
   }
 
-  public void enableDisableGeneralNotificationsOnMobile() {
-    settingsPage.enableDisableGeneralNotificationsOnMobile();
-
-  }
-
-  public void enableDisableGeneralNotificationsOnSite() {
-    settingsPage.enableDisableGeneralNotificationsOnSite();
-
-  }
-
-  public void enableDisableGeneralNotificationsViaMail() {
-    settingsPage.enableDisableGeneralNotificationsViaMail();
-
-  }
-
   public void enableDisableNotificationOnMobile() {
     settingsPage.enableDisableNotificationOnMobile();
 

--- a/src/test/java/io/meeds/qa/ui/steps/definition/SettingsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/SettingsStepDefinition.java
@@ -177,27 +177,6 @@ public class SettingsStepDefinition {
     settingsSteps.editPassword(firstUserPassword, firstUserEditedPassword);
   }
 
-  @When("^I enable General notifications On Mobile$")
-  @And("^I disable General notifications On Mobile$")
-  public void enableDisableGeneralNotificationsOnMobile() {
-    settingsSteps.enableDisableGeneralNotificationsOnMobile();
-
-  }
-
-  @When("^I enable General notifications On Site$")
-  @And("^I disable General notifications On Site$")
-  public void enableDisableGeneralNotificationsOnSite() {
-    settingsSteps.enableDisableGeneralNotificationsOnSite();
-
-  }
-
-  @When("^I enable General notifications Via Mail$")
-  @And("^I disable General notifications Via Mail$")
-  public void enableDisableGeneralNotificationsViaMail() {
-    settingsSteps.enableDisableGeneralNotificationsViaMail();
-
-  }
-
   @When("I enable notification on Mobile")
   @And("I disable notification on Mobile")
   public void enableDisableNotificationOnMobile() {

--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -76,30 +76,31 @@ Feature: Edit sections in Settings page
 
     Then I connect with the first created user
 
+  @test
   Scenario: : SETTINGS-8 : Notifications section (Disable Notifications)
     Given I am authenticated as admin
 
     When I create the first random user if not existing
-
-    Then I connect with the first created user
-
+    And I connect with the first created user
     And I go to Settings page
     Then Settings Page Is Opened
 
     When I disable notification via Mail
-    And I disable notification on Mobile
-    And I disable notification on Site
-
     Then Notification via Mail is disabled
+
+    When I disable notification on Mobile
     Then Notification On Mobile is disabled
+
+    When I disable notification on Site
     Then Notification On Site is disabled
 
     When I enable notification via Mail
-    And I enable notification on Mobile
-    And I enable notification on Site
-
     Then Notification via Mail is enabled
+
+    When I enable notification on Mobile
     Then Notification On Mobile is enabled
+
+    When I enable notification on Site
     Then Notification On Site is enabled
 
   Scenario: SETTINGS-4 : Add the favorite icon for Homepage default view

--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -76,7 +76,6 @@ Feature: Edit sections in Settings page
 
     Then I connect with the first created user
 
-  @test
   Scenario: : SETTINGS-8 : Notifications section (Disable Notifications)
     Given I am authenticated as admin
 

--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -80,7 +80,7 @@ Feature: Edit sections in Settings page
   Scenario: : SETTINGS-8 : Notifications section (Disable Notifications)
     Given I am authenticated as admin
 
-    When I create the first random user if not existing
+    When I create the first random user if not existing, no wait
     And I connect with the first created user
     And I go to Settings page
     Then Settings Page Is Opened


### PR DESCRIPTION
Prior tot his change, the Notifications Settings Test fails randomly due to the fact that sometimes, the switch button status (checked or unchecked) is verified before the switch animation finishes. This change will ensure to not make the check until waiting the animation to finish.