### PR TITLE
fix: Fix Random fail related to Admin language - MEED-715

### DIFF
--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -5,6 +5,8 @@ Feature: Edit sections in Settings page
 
   Scenario: [SETTINGS-5] Language and its drawer
     Given I am authenticated as admin
+    And I create the firstlang random user if not existing
+    And I connect with the firstlang created user
 
     And I go to Settings page
     Then Settings Page Is Opened


### PR DESCRIPTION
Prior to this change, a test case uses admin user to check on languages switching. This change will make the user language test case executes using a dedicated random user to not making fail other test cases when it does.