### PR TITLE
fix: Fix Random fail related to Admin language And Work Experience Start Date - MEED-715

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/people/UserProfilePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/people/UserProfilePage.java
@@ -146,9 +146,6 @@ public class UserProfilePage extends GenericPage {
   @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-header')]//button[1]")
   private TextBoxElementFacade   elementWorkExperiencesStartDateGoToPreviousMonth;
 
-  @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table')]//td//*[text() = '1']")
-  private TextBoxElementFacade   elementWorkExperiencesStartDateFirstMonthDay;
-
   @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[2]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table__current')]")
   private TextBoxElementFacade   elementWorkExperiencesEndDateToday;
 
@@ -555,7 +552,11 @@ public class UserProfilePage extends GenericPage {
 
     elementWorkExperiencesStartDate.clickOnElement();
     elementWorkExperiencesStartDateGoToPreviousMonth.clickOnElement();
+    waitFor(200).milliseconds(); // Wait until animation finishes
+    BaseElementFacade elementWorkExperiencesStartDateFirstMonthDay =
+                                                                   findByXPathOrCSS("(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table')]//td//*[text() = '1']//ancestor::button");
     elementWorkExperiencesStartDateFirstMonthDay.clickOnElement();
+    waitFor(200).milliseconds(); // Wait until animation finishes
 
     elementWorkExperiencesEndDate.clickOnElement();
     elementWorkExperiencesEndDateToday.clickOnElement();

--- a/src/main/java/io/meeds/qa/ui/pages/page/factory/people/UserProfilePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/page/factory/people/UserProfilePage.java
@@ -146,7 +146,7 @@ public class UserProfilePage extends GenericPage {
   @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-header')]//button[1]")
   private TextBoxElementFacade   elementWorkExperiencesStartDateGoToPreviousMonth;
 
-  @FindBy(xpath = "((//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table')]//td)[1]//button")
+  @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[1]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table')]//td//*[text() = '1']")
   private TextBoxElementFacade   elementWorkExperiencesStartDateFirstMonthDay;
 
   @FindBy(xpath = "(//*[contains(@class, 'profileWorkExperiencesDates')]//*[contains(@class, 'datePickerComponent')])[2]//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table__current')]")

--- a/src/test/resources/features/Meeds/MeedsProfile.feature
+++ b/src/test/resources/features/Meeds/MeedsProfile.feature
@@ -104,7 +104,6 @@ Feature: Search for User Informations in Profile page
     Then Sent Kudos Section is displayed
     Then Gained Cauris Section is displayed
 
-  @test
   Scenario: : PROFILE-7 : Work Experiences block and its drawer
     Given I am authenticated as admin
 

--- a/src/test/resources/features/Meeds/MeedsProfile.feature
+++ b/src/test/resources/features/Meeds/MeedsProfile.feature
@@ -104,6 +104,7 @@ Feature: Search for User Informations in Profile page
     Then Sent Kudos Section is displayed
     Then Gained Cauris Section is displayed
 
+  @test
   Scenario: : PROFILE-7 : Work Experiences block and its drawer
     Given I am authenticated as admin
 

--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -5,6 +5,8 @@ Feature: Edit sections in Settings page
 
   Scenario: [SETTINGS-5] Language and its drawer
     Given I am authenticated as admin
+    And I create the firstlang random user if not existing
+    And I connect with the firstlang created user
 
     And I go to Settings page
     Then Settings Page Is Opened


### PR DESCRIPTION
Prior to this change, a test case uses admin user to check on languages switching. This change will make the user language test case executes using a dedicated random user to not making fail other test cases when it does.

In addition, the XPath of Start date button from Date Picker isn't pertinent all time. This change will fix it to consider special use cases.