### PR TITLE
fix: Delete Unstable Test Case of deprecated TimeZone Setting UI - MEED-779

### DIFF
--- a/src/test/resources/features/Meeds/MeedsSettings.feature
+++ b/src/test/resources/features/Meeds/MeedsSettings.feature
@@ -27,29 +27,6 @@ Feature: Edit sections in Settings page
     When I refresh the page
     Then Language 'English / English' is displayed
 
-  # Default timezone for some servers may be different from (GMT +01:00) Central European Standard Time
-  @standardConfigurationOnly
-  Scenario: [SETTINGS-6] TimeZone view and drawer
-    Given I am authenticated as admin
-
-    And I go to Settings page
-    Then Settings Page Is Opened
-
-    When I click on Edit time zone and I change it '+02:00'
-    And I cancel editing time zone
-
-    Then Time zone '(GMT +01:00) Central European Standard Time' is displayed
-
-    When I click on Edit time zone and I change it '+02:00'
-    And I accept editing language
-
-    Then Time zone '(GMT +02:00) Central Africa Time' is displayed
-
-    When I click on Edit time zone and I change it '+01:00'
-    And I accept editing language
-
-    Then Time zone '(GMT +01:00) Central European Standard Time' is displayed
-
   @ignored
   Scenario: [SETTINGS-7] Security on settings
     Given I connect as admin if random users doesn't exists


### PR DESCRIPTION
The TimeZone Drawer settings Test isn't stable due to labels that can change switch used version of JRE/JDK on server and which maintenance version (TimeZones localization updates).

In addition this UI is deprecated and should be removed from product because it's useless. Thus, this Test case has to be removed instead of investing Time to stabilize it.