### PR TITLE
fix: Stabilize Tests when JS and CSS loading timed out - MEED-1628

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
             <webdriver.base.url>http://localhost:8080/</webdriver.base.url>
             <webdriver.remote.driver>chrome</webdriver.remote.driver>
             <cucumber.filter.tags>not @ignored and not @ignore and not @wip and not @skip</cucumber.filter.tags>
-            <adminPassword></adminPassword>
+            <adminPassword>Test1234@</adminPassword>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/src/main/java/io/meeds/qa/ui/utils/Utils.java
+++ b/src/main/java/io/meeds/qa/ui/utils/Utils.java
@@ -290,7 +290,7 @@ public class Utils {
     }
   }
 
-  private static void waitForInMillis(long timeInMilliseconds) {
+  public static void waitForInMillis(long timeInMilliseconds) {
     try {
       Thread.sleep(timeInMilliseconds);
     } catch (InterruptedException e) {

--- a/src/test/java/io/meeds/qa/ui/hook/TestHooks.java
+++ b/src/test/java/io/meeds/qa/ui/hook/TestHooks.java
@@ -191,6 +191,9 @@ public class TestHooks {
         reloadPageJavascript(javascriptExecutorFacade);
         reloadPageCSS(javascriptExecutorFacade);
 
+        // Wait 2 seconds for assets to reload
+        Utils.waitForInMillis(2000);
+
         // Refresh the page
         driver.get(driver.getCurrentUrl().split("/portal")[0]);
 


### PR DESCRIPTION
Prior to this change, when the Nginx timeout is reached (60 seconds) after loading the portal the first time, all tests continues to fail. This change will make assertion at the beginning of all Tests on JS console errors to ensure, before executing tests, to not have an inconsistent state and to fail fast for all tests after attempting to reload assets.