### PR TITLE
Fix: Add adaptations for CSS changes on App Center Popup - MEED-1891 - Meeds-io/MIPs#52

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
@@ -345,16 +345,16 @@ public class ApplicationPage extends GenericPage {
                                           appUrl));
   }
 
-  private ElementFacade cancelDeleteButtonElement() {
-    return findByXPathOrCSS("//div[@class='btn']");
-  }
-
   private ElementFacade closeDeletePopupButtonElement() {
-    return findByXPathOrCSS("//button[contains(@class,'closeBindingModal')]");
+    return findByXPathOrCSS(".v-dialog--active .uiIconClose");
   }
 
   private ElementFacade confirmDeleteElement() {
-    return findByXPathOrCSS("//div[@id='deleteBtn']");
+    return findByXPathOrCSS("//*[contains(@class, 'v-dialog--active')]//button[contains(text(), 'Delete')]");
+  }
+
+  private ElementFacade cancelDeleteButtonElement() {
+    return findByXPathOrCSS("//*[contains(@class, 'v-dialog--active')]//button[contains(text(), 'Cancel')]");
   }
 
   private ElementFacade editApplicationDrawerImageElement() {


### PR DESCRIPTION
This change will adapt CSS Classes change for App Center Popup which has been changed to re-use a common component for confirmation dialog instead of a specific one. In addition, the CKEditor loading waiting has been added in some places to make sure that it's loaded before proceeding to add content into it.