### PR TITLE
fix: stabilize Achievements Test Cases - MEED-2094

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,16 +244,12 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.0</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
@@ -30,6 +30,8 @@ import io.meeds.qa.ui.utils.Utils;
 
 public class AchievementsPage extends GenericPage {
 
+  private static final int MAX_REFRESH_RETRIES = 30;
+
   public AchievementsPage(WebDriver driver) {
     super(driver);
   }
@@ -49,7 +51,7 @@ public class AchievementsPage extends GenericPage {
                        waitFor(2).seconds();
                        Utils.refreshPage(true);
                      },
-                     10);
+                     MAX_REFRESH_RETRIES);
   }
 
   public void checkThatAchievementIsRejected(String actionTitle) {
@@ -63,8 +65,7 @@ public class AchievementsPage extends GenericPage {
     }, () -> {
       waitFor(2).seconds();
       Utils.refreshPage(true);
-    },
-    10);
+    }, MAX_REFRESH_RETRIES);
   }
 
   public void checkThatAchievementIsCanceled(String actionTitle) {
@@ -78,8 +79,7 @@ public class AchievementsPage extends GenericPage {
     }, () -> {
       waitFor(2).seconds();
       Utils.refreshPage(true);
-    },
-    10);
+    }, MAX_REFRESH_RETRIES);
   }
 
   public void checkThatAchievementIsDeleted(String actionTitle) {
@@ -93,8 +93,7 @@ public class AchievementsPage extends GenericPage {
     }, () -> {
       waitFor(2).seconds();
       Utils.refreshPage(true);
-    },
-    10);
+    }, MAX_REFRESH_RETRIES);
   }
 
   public void checkThatAchievementIsDisplayed(String actionTitle, long times) {
@@ -110,7 +109,24 @@ public class AchievementsPage extends GenericPage {
     }, () -> {
       waitFor(2).seconds();
       Utils.refreshPage(true);
-    }, 10);
+    }, MAX_REFRESH_RETRIES);
+  }
+
+  public void checkThatAchievementIsDisplayed(String actionTitle, long times, String programName) {
+    retryOnCondition(() -> {
+      filterAchievementByProgram(programName);
+      int found = findAll(By.xpath(String.format("//*[contains(@id, 'GamificationRealizationItem')]//*[contains(text(), '%s')]",
+                                                 actionTitle))).size();
+      if (times != found) {
+        throw new IllegalStateException(String.format("Expected to find '%s' achievement %s times, but was %s times",
+                                                      actionTitle,
+                                                      times,
+                                                      found));
+      }
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    }, MAX_REFRESH_RETRIES);
   }
 
   private ElementFacade rejectedAchievementElement(String actionTitle) {

--- a/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
@@ -33,7 +33,7 @@ import io.meeds.qa.ui.utils.Utils;
 
 public class AchievementsPage extends GenericPage {
 
-  private static final int MAX_REFRESH_RETRIES = 30;
+  private static final int MAX_REFRESH_RETRIES = 5;
 
   public AchievementsPage(WebDriver driver) {
     super(driver);
@@ -112,11 +112,10 @@ public class AchievementsPage extends GenericPage {
     }
   }
 
-  public void checkThatAchievementIsDisplayedWithSwitchEnabled(String actionTitle, long times, String switchButtonName) {
+  public void checkThatAchievementIsDisplayedWithProgramOwnerView(String actionTitle, long times, String programName) {
     String errorMessage = retryGetOnCondition(() -> {
-      enableSwitchButtonDisplayed(switchButtonName);
-      waitFor(300).milliseconds();
-      waitForLoading();
+      enableProgramOwnerView();
+      filterAchievementByProgram(programName);
       long found = achievementsCount(actionTitle);
       return checkAchievementsCount(actionTitle, times, found);
     }, () -> {
@@ -140,6 +139,18 @@ public class AchievementsPage extends GenericPage {
     if (StringUtils.isNotBlank(errorMessage)) {
       fail(errorMessage);
     }
+  }
+
+  private void enableProgramOwnerView() {
+    ElementFacade programOwnerSwitchButton = programOwnerSwitchButton();
+    programOwnerSwitchButton.assertVisible();
+    programOwnerSwitchButton.click();
+    waitFor(200).milliseconds();
+    waitForLoading();
+  }
+
+  private ElementFacade programOwnerSwitchButton() {
+    return findByXPathOrCSS("//*[@id='realizationAdministrationSwitch']//ancestor::*[contains(@class, 'v-input--selection-controls') and contains(@class, 'v-input--switch')]");
   }
 
   private ElementFacade rejectedAchievementElement(String actionTitle) {

--- a/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/AchievementsPage.java
@@ -17,8 +17,9 @@
  */
 package io.meeds.qa.ui.pages;
 
-import static io.meeds.qa.ui.utils.Utils.*;
-import static org.junit.Assert.assertEquals;
+import static io.meeds.qa.ui.utils.Utils.retryOnCondition;
+import static io.meeds.qa.ui.utils.Utils.waitForLoading;
+import static io.meeds.qa.ui.utils.Utils.waitForPageLoading;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -43,7 +44,12 @@ public class AchievementsPage extends GenericPage {
 
   public void checkThatAchievementIsAccepted(String actionTitle) {
     waitForPageLoading();
-    retryOnCondition(() -> acceptedAchievementElement(actionTitle).checkVisible(), Utils::refreshPage);
+    retryOnCondition(() -> acceptedAchievementElement(actionTitle).checkVisible(),
+                     () -> {
+                       waitFor(2).seconds();
+                       Utils.refreshPage(true);
+                     },
+                     10);
   }
 
   public void checkThatAchievementIsRejected(String actionTitle) {
@@ -54,7 +60,11 @@ public class AchievementsPage extends GenericPage {
       rejectedAchievementElement.hover();
       ElementFacade tooltipRejectedElement = tooltipRejectedElement();
       tooltipRejectedElement.checkVisible();
-    }, Utils::refreshPage);
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    },
+    10);
   }
 
   public void checkThatAchievementIsCanceled(String actionTitle) {
@@ -65,7 +75,11 @@ public class AchievementsPage extends GenericPage {
       rejectedAchievementElement.hover();
       ElementFacade tooltipCanceledElement = tooltipCanceledElement();
       tooltipCanceledElement.checkVisible();
-    }, Utils::refreshPage);
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    },
+    10);
   }
 
   public void checkThatAchievementIsDeleted(String actionTitle) {
@@ -76,15 +90,27 @@ public class AchievementsPage extends GenericPage {
       rejectedAchievementElement.hover();
       ElementFacade tooltipDeletedActivity = tooltipDeletedActivity();
       tooltipDeletedActivity.checkVisible();
-    }, Utils::refreshPage);
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    },
+    10);
   }
 
   public void checkThatAchievementIsDisplayed(String actionTitle, long times) {
-    int found = findAll(By.xpath(String.format("//*[contains(@id, 'GamificationRealizationItem')]//*[contains(text(), '%s')]",
-                                               actionTitle))).size();
-    assertEquals("Achievements count doesn't match",
-                 times,
-                 found);
+    retryOnCondition(() -> {
+      int found = findAll(By.xpath(String.format("//*[contains(@id, 'GamificationRealizationItem')]//*[contains(text(), '%s')]",
+                                                 actionTitle))).size();
+      if (times != found) {
+        throw new IllegalStateException(String.format("Expected to find '%s' achievement %s times, but was %s times",
+                                                      actionTitle,
+                                                      times,
+                                                      found));
+      }
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    }, 10);
   }
 
   private ElementFacade rejectedAchievementElement(String actionTitle) {

--- a/src/main/java/io/meeds/qa/ui/pages/ChallengesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ChallengesPage.java
@@ -26,10 +26,6 @@ public class ChallengesPage extends GenericPage {
     searchChallengeElement().setTextValue(challengeName);
     waitFor(1).seconds();
     waitForLoading();
-    TextBoxElementFacade expandProgramChallengesElement = expandProgramChallengesElement();
-    if (expandProgramChallengesElement.isCurrentlyVisible()) {
-      expandProgramChallengesElement.click();
-    }
   }
 
   public void cancelAnnouncementChallenge(String announcement) {
@@ -50,10 +46,6 @@ public class ChallengesPage extends GenericPage {
 
   private TextBoxElementFacade searchChallengeElement() {
     return findTextBoxByXPathOrCSS("//input[@id='EngagementCenterApplicationSearchFilter']");
-  }
-
-  private TextBoxElementFacade expandProgramChallengesElement() {
-    return findTextBoxByXPathOrCSS("//*[contains(@class, 'v-expansion-panel-header')]//*[contains(@class, 'fa-chevron-down')]");
   }
 
   private ElementFacade challengeByNameAndPoints(String challengeName, String points) {

--- a/src/main/java/io/meeds/qa/ui/pages/ChallengesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ChallengesPage.java
@@ -15,8 +15,13 @@ public class ChallengesPage extends GenericPage {
 
   public void openEditChallengeDrawer(String challengeName) {
     searchChallenge(challengeName);
-    editChallengeThreeDots(challengeName).click();
+    challengeCard(challengeName).hover();
+    ElementFacade menuThreeDots = editChallengeThreeDots(challengeName);
+    menuThreeDots.assertVisible();
+    menuThreeDots.click();
     editChallengeButton(challengeName).click();
+    waitForDrawerToOpen();
+    waitForLoading();
   }
 
   public void searchChallenge(String challengeName) {
@@ -45,22 +50,27 @@ public class ChallengesPage extends GenericPage {
   }
 
   private TextBoxElementFacade searchChallengeElement() {
-    return findTextBoxByXPathOrCSS("//input[@id='EngagementCenterApplicationSearchFilter']");
+    return findTextBoxByXPathOrCSS("//input[@id='rulesFilterInput']");
   }
 
   private ElementFacade challengeByNameAndPoints(String challengeName, String points) {
-    return findByXPathOrCSS(String.format("//*[@id='ChallengesApplication']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'engagement-center-card')]//*[contains(text(), '%s Points')]",
+    return findByXPathOrCSS(String.format("//*[@id='rulesList']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'rule-card-info')]//*[contains(text(), '%s Points')]",
                                           challengeName,
                                           points));
   }
 
   private ElementFacade editChallengeThreeDots(String challengeName) {
-    return findByXPathOrCSS(String.format("//*[@id='ChallengesApplication']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'engagement-center-card')]//*[contains(@class, 'fa-ellipsis')]",
+    return findByXPathOrCSS(String.format("//*[@id='rulesList']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'rule-card-info')]//*[contains(@class, 'fa-ellipsis')]",
+                                          challengeName));
+  }
+
+  private ElementFacade challengeCard(String challengeName) {
+    return findByXPathOrCSS(String.format("//*[@id='rulesList']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'rule-card-info')]",
                                           challengeName));
   }
 
   private ElementFacade editChallengeButton(String challengeName) {
-    return findByXPathOrCSS(String.format("//*[@id='ChallengesApplication']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'engagement-center-card')]//*[contains(@class, 'v-menu')]//*[contains(text(), 'Edit')]",
+    return findByXPathOrCSS(String.format("//*[@id='rulesList']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'rule-card-info')]//*[contains(@class, 'v-menu')]//*[contains(text(), 'Edit')]",
                                           challengeName));
   }
 

--- a/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
@@ -86,7 +86,7 @@ public class GenericPage extends BasePageImpl {
   }
 
   public void enableSwitchButtonDisplayed(String buttonName) {
-    findByXPathOrCSS(String.format("//*[contains(text(), '%s')]/parent::*//*[contains(@class, 'v-input--switch') and contains(@class, 'v-input--selection-controls')]", buttonName)).click();
+    findByXPathOrCSS(String.format("//*[contains(text(), '%s')]/parent::*//*[contains(@class, 'v-input--switch')]", buttonName)).click();
   }
 
   private ElementFacade getConfirmMessage(String message) {

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -447,7 +447,6 @@ public class HomePage extends GenericPage {
     retryOnCondition(() -> getHamburgerNavigationMenu().click(),
                      () -> {
                        LOGGER.warn("Hamburger Menu isn't visible, retry by waiting until application is built");
-                       getHamburgerNavigationMenuDrawer().waitUntilPresent();
                        closeAllDrawers();
                      });
     waitForDrawerToOpen();

--- a/src/main/java/io/meeds/qa/ui/pages/KudosPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/KudosPage.java
@@ -32,6 +32,8 @@ public class KudosPage extends GenericPage {
   private static final String ACTIVITY_KUDOS_DRAWER_SELECTOR =
                                                              "//*[@id='activityKudosDrawer' and contains(@class, 'v-navigation-drawer--open')]";
 
+  private SpaceHomePage       spaceHomePage;
+
   public KudosPage(WebDriver driver) {
     super(driver);
   }
@@ -78,11 +80,17 @@ public class KudosPage extends GenericPage {
   }
 
   public void cancelKudosActivity(String activity) {
+    if (!getCancelKudosActivityIcon(activity).isVisible()) {
+      spaceHomePage.openThreeDotsActivityMenu(activity);
+    }
     getCancelKudosActivityIcon(activity).click();
   }
 
-  public void cancelKudosComment(String comment) {
-    getCancelKudosCommentIcon(comment).click();
+  public void cancelKudosComment(String activity, String kudos) {
+    if (!getCancelKudosCommentIcon(kudos).isVisible()) {
+      spaceHomePage.openThreeDotsCommentMenu(activity, kudos);
+    }
+    getCancelKudosCommentIcon(kudos).click();
   }
 
   public void enterKudosNumber(String val) {
@@ -256,7 +264,7 @@ public class KudosPage extends GenericPage {
 
   private ElementFacade getCancelKudosActivityIcon(String activity) {
     return findByXPathOrCSS(String.format("//*[contains(text(), '%s')]//ancestor::*[contains(@id, 'activity-detail')]//*[contains(@class, 'menuable__content__active')]//*[contains(@class, 'undo')]",
-            activity));
+                                          activity));
   }
 
   private ElementFacade getCancelKudosCommentIcon(String comment) {

--- a/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.WebDriver;
 
 import io.meeds.qa.ui.elements.ElementFacade;
 import io.meeds.qa.ui.elements.TextBoxElementFacade;
+import io.meeds.qa.ui.utils.Utils;
 import net.serenitybdd.markers.IsHidden;
 import net.thucydides.core.annotations.DefaultUrl;
 
@@ -91,19 +92,26 @@ public class LoginPage extends GenericPage implements IsHidden {
   }
 
   public void logout() {
+    logout(1, Utils.MAX_WAIT_RETRIES);
+    usernameInputElement().assertVisible();
+  }
+
+  private void logout(int tentative, int max) {
     if (homePage.isPortalDisplayed()) {
-      try {
-        ElementFacade logOutMenuElement = logOutMenuElement();
-        if (!logOutMenuElement.isCurrentlyVisible()) {
-          closeAllDrawers();
-          homePage.clickOnHamburgerMenu();
-        }
-        logOutMenuElement.click();
-        waitFor(50).milliseconds();
-        verifyPageLoaded();
-        usernameInputElement().checkVisible();
-      } finally {
+      ElementFacade logOutMenuElement = logOutMenuElement();
+      if (!logOutMenuElement.isCurrentlyVisible()) {
+        closeAllDrawers();
+        waitFor(200).milliseconds();
+        homePage.clickOnHamburgerMenu();
+      }
+      logOutMenuElement.click();
+      verifyPageLoaded();
+      if (usernameInputElement().isVisible()) {
         deleteLastLoginCookie();
+      } else {
+        LOGGER.warn("Error logout, tentative {}/{}. Retry by refreshing page.", tentative, max);
+        Utils.refreshPage(true);
+        logout(tentative + 1, max);
       }
     } else if (!isLoginPageDisplayed()) {
       openLoginPage();

--- a/src/main/java/io/meeds/qa/ui/pages/ProgramsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ProgramsPage.java
@@ -203,12 +203,16 @@ public class ProgramsPage extends GenericPage {
     mentionInField(programOwnerSuggester(), fullName, 3);
   }
 
+  public void checkAdminActionsFilterIsDisplayed() {
+    filterAdminActionsDropdown().assertVisible();
+  }
+
+  public void checkAdminActionsFilterIsNotDisplayed() {
+    filterAdminActionsDropdown().assertNotVisible();
+  }
+
   public void checkActionsFilterIsDisplayed() {
     filterActionsDropdown().assertVisible();
-  }
-  
-  public void checkActionsFilterIsNotDisplayed() {
-    filterActionsDropdown().assertNotVisible();
   }
 
   private TextBoxElementFacade programOwnerSuggester() {
@@ -318,7 +322,11 @@ public class ProgramsPage extends GenericPage {
   }
 
   private ElementFacade filterActionsDropdown() {
-    return findByXPathOrCSS("//*[@id='engagementCenterProgramDetail']//option[@value='ENABLED']/parent::select");
+    return findByXPathOrCSS("//*[@id='engagementCenterProgramDetail']//option[@value='ALL']/parent::select");
+  }
+
+  private ElementFacade filterAdminActionsDropdown() {
+    return findByXPathOrCSS("//*[@id='engagementCenterProgramDetail']//option[@value='DISABLED']/parent::select");
   }
 
   private ElementFacade announceChallengeActionFromDrawer() {

--- a/src/main/java/io/meeds/qa/ui/pages/RulePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/RulePage.java
@@ -17,12 +17,9 @@
  */
 package io.meeds.qa.ui.pages;
 
-import io.meeds.qa.ui.elements.ButtonElementFacade;
-
-import static io.meeds.qa.ui.utils.Utils.waitForLoading;
-
 import org.openqa.selenium.WebDriver;
 
+import io.meeds.qa.ui.elements.ButtonElementFacade;
 import io.meeds.qa.ui.elements.ElementFacade;
 import io.meeds.qa.ui.elements.TextBoxElementFacade;
 
@@ -63,7 +60,6 @@ public class RulePage extends GenericPage {
 
     clickOnSaveButton(newRule);
     waitForDrawerToClose();
-    waitForLoading();
   }
 
   public void selectDurationChoice() {
@@ -104,6 +100,7 @@ public class RulePage extends GenericPage {
   }
 
   public void setActionEndDate() {
+    selectActionDateChoice("BEFORE");
     actionEndDateElement().click();
     waitForMenuToOpen();
     randomDateCalenderElement().waitUntilVisible();
@@ -150,6 +147,18 @@ public class RulePage extends GenericPage {
 
   public void clearRulesSearchFilter() {
     clearSearchBtnElement().click();
+  }
+
+  private void selectActionDateChoice(String value) {
+    ElementFacade selectActionDateElement =
+                                          selectActionDateElement(value);
+    selectActionDateElement.selectByValue(value);
+    waitFor(50).milliseconds();
+  }
+
+  private ElementFacade selectActionDateElement(String value) {
+    return findByXPathOrCSS(String.format("//*[contains(@class, 'v-navigation-drawer--open')]//option[@value='%s']//parent::select",
+                                          value));
   }
 
   private ElementFacade ruleEnableSwitchButton() {
@@ -240,7 +249,7 @@ public class RulePage extends GenericPage {
 
   public ElementFacade actionInProgramDetailElement(String ruleTitle) {
     return findByXPathOrCSS(String.format("//*[@class='v-data-table__wrapper']//*[@class='text-truncate' and contains(@title,'%s')][1]",
-            ruleTitle));
+                                          ruleTitle));
   }
 
   public ElementFacade ruleNotfoundTryAgainElement() {

--- a/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
@@ -36,6 +36,7 @@ import org.openqa.selenium.support.ui.Select;
 
 import io.meeds.qa.ui.elements.ElementFacade;
 import io.meeds.qa.ui.elements.TextBoxElementFacade;
+import io.meeds.qa.ui.utils.Utils;
 import net.serenitybdd.core.Serenity;
 
 public class SpaceHomePage extends GenericPage {
@@ -221,7 +222,10 @@ public class SpaceHomePage extends GenericPage {
   }
 
   public void checkActivityCommentNotDisplayed(String activity, String comment) {
-    getDropDownCommentMenu(activity, comment).assertNotVisible();
+    retryOnCondition(() -> getDropDownCommentMenu(activity, comment).checkNotVisible(), () -> {
+      waitFor(3).seconds();
+      Utils.refreshPage();
+    });
   }
 
   public void checkActivityNotVisible(String activity) {
@@ -452,6 +456,7 @@ public class SpaceHomePage extends GenericPage {
 
   public void clickYesbutton() {
     findByXPathOrCSS(CONFIRMATION_BUTTON_TO_DELETE_ACTIVITY_SELECTOR).click();
+    waitForLoading();
   }
 
   public void commentIsDisplayedInDrawer(String commentsNumber, String comment) {
@@ -801,6 +806,18 @@ public class SpaceHomePage extends GenericPage {
 
   public void openThreeDotsActivityMenu(String activity) {
     getDropDownActivityMenu(activity).click();
+  }
+
+  public boolean isThreeDotsActivityMenuOpen(String activity) {
+    return getDropDownActivityMenu(activity).isVisible();
+  }
+
+  public void openThreeDotsCommentMenu(String activity, String comment) {
+    getDropDownCommentMenu(activity, comment).click();
+  }
+
+  public boolean isThreeDotsCommentMenuOpen(String activity, String comment) {
+    return getDropDownCommentMenu(activity, comment).isVisible();
   }
 
   public void pinActivityButtonIsDisplayed(String activity) {
@@ -1304,12 +1321,12 @@ public class SpaceHomePage extends GenericPage {
   }
 
   private ElementFacade getDropDownActivityMenu(String activity) {
-    return findByXPathOrCSS(String.format("//*[contains(text(),'%s')]//ancestor::div[contains(@class,'contentBox')]//*[contains(@class, 'activity-head')]//*[contains(@class,'fa-ellipsis-v')]",
+    return findByXPathOrCSS(String.format("(//*[contains(text(),'%s')]//ancestor::div[contains(@class,'contentBox')]//*[contains(@class, 'activity-head')]//*[contains(@class,'fa-ellipsis-v')])[1]",
                                           activity));
   }
 
   private ElementFacade getDropDownCommentMenu(String activity, String comment) {
-    return findByXPathOrCSS(String.format("//div[contains(@class,'contentBox')]//*[contains(text(),'%s')]//following::*[contains(@class,'activity-comment')]//*[contains(@class,'rich-editor-content')]//*[contains(text(),'%s')]/preceding::button[@class='v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small'][1]",
+    return findByXPathOrCSS(String.format("(//div[contains(@class,'contentBox')]//*[contains(text(),'%s')]//following::*[contains(@class,'activity-comment')]//*[contains(@class,'rich-editor-content')]//*[contains(text(),'%s')]/preceding::button[@class='v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small'])[1]",
                                           activity,
                                           comment));
   }

--- a/src/main/java/io/meeds/qa/ui/pages/UserProfilePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/UserProfilePage.java
@@ -18,6 +18,8 @@
 package io.meeds.qa.ui.pages;
 
 import static io.meeds.qa.ui.utils.Utils.refreshPage;
+import static io.meeds.qa.ui.utils.Utils.retryOnCondition;
+import static io.meeds.qa.ui.utils.Utils.waitForPageLoading;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
@@ -28,6 +30,7 @@ import org.openqa.selenium.interactions.Actions;
 
 import io.meeds.qa.ui.elements.ElementFacade;
 import io.meeds.qa.ui.elements.TextBoxElementFacade;
+import io.meeds.qa.ui.utils.Utils;
 
 public class UserProfilePage extends GenericPage {
 
@@ -409,6 +412,21 @@ public class UserProfilePage extends GenericPage {
     String js = "arguments[0].style.height='auto'; arguments[0].style.visibility='visible';";
     ((JavascriptExecutor) getDriver()).executeScript(js, elem);
     upload(UPLOAD_DIRECTORY_PATH + fileName).fromLocalMachine().to(elem);
+  }
+
+  public void checkMyPointIncrease(int originalWeeklyPoint) {
+    waitForPageLoading();
+    retryOnCondition(() -> {
+      int myWeeklyPoint = getMyWeeklyPoint();
+      if (myWeeklyPoint <= originalWeeklyPoint) {
+        throw new IllegalStateException(String.format("Weekly points %s wasn't increased, original points = %s",
+                                                      myWeeklyPoint,
+                                                      originalWeeklyPoint));
+      }
+    }, () -> {
+      waitFor(2).seconds();
+      Utils.refreshPage(true);
+    }, 10);
   }
 
   private ElementFacade achievementsDrawerElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
@@ -47,4 +47,8 @@ public class AchievementsSteps {
     achievementsPage.checkThatAchievementIsDisplayed(actionTitle, times);
   }
 
+  public void checkThatAchievementIsDisplayed(String actionTitle, long times, String programName) {
+    achievementsPage.checkThatAchievementIsDisplayed(actionTitle, times, programName);
+  }
+
 }

--- a/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
@@ -47,6 +47,10 @@ public class AchievementsSteps {
     achievementsPage.checkThatAchievementIsDisplayed(actionTitle, times);
   }
 
+  public void checkThatAchievementIsDisplayedWithSwitchEnabled(String actionTitle, long times, String switchButtonName) {
+    achievementsPage.checkThatAchievementIsDisplayedWithSwitchEnabled(actionTitle, times, switchButtonName);
+  }
+
   public void checkThatAchievementIsDisplayed(String actionTitle, long times, String programName) {
     achievementsPage.checkThatAchievementIsDisplayed(actionTitle, times, programName);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/AchievementsSteps.java
@@ -47,8 +47,8 @@ public class AchievementsSteps {
     achievementsPage.checkThatAchievementIsDisplayed(actionTitle, times);
   }
 
-  public void checkThatAchievementIsDisplayedWithSwitchEnabled(String actionTitle, long times, String switchButtonName) {
-    achievementsPage.checkThatAchievementIsDisplayedWithSwitchEnabled(actionTitle, times, switchButtonName);
+  public void checkThatAchievementIsDisplayedWithProgramOwnerView(String actionTitle, long times, String programName) {
+    achievementsPage.checkThatAchievementIsDisplayedWithProgramOwnerView(actionTitle, times, programName);
   }
 
   public void checkThatAchievementIsDisplayed(String actionTitle, long times, String programName) {

--- a/src/test/java/io/meeds/qa/ui/steps/KudosSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/KudosSteps.java
@@ -63,14 +63,13 @@ public class KudosSteps {
   }
 
   public void cancelActivityKudos(String activity) {
-    spaceHomePage.openThreeDotsActivityMenu(activity);
     kudosPage.cancelKudosActivity(activity);
     spaceHomePage.clickYesbutton();
   }
 
   public void cancelCommentKudos(String activity, String comment) {
     spaceHomePage.clickOnCommentThreeDotsButton(activity, comment);
-    kudosPage.cancelKudosComment(comment);
+    kudosPage.cancelKudosComment(activity, comment);
     spaceHomePage.clickYesbutton();
   }
 

--- a/src/test/java/io/meeds/qa/ui/steps/ProgramsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/ProgramsSteps.java
@@ -152,12 +152,16 @@ public class ProgramsSteps {
     programsPage.addProgramOwner(fullName);
   }
 
-  public void checkActionsFilterIsNotDisplayed() {
-    programsPage.checkActionsFilterIsNotDisplayed();
-  }
-
   public void checkActionsFilterIsDisplayed() {
     programsPage.checkActionsFilterIsDisplayed();
+  }
+
+  public void checkAdminActionsFilterIsNotDisplayed() {
+    programsPage.checkAdminActionsFilterIsNotDisplayed();
+  }
+  
+  public void checkAdminActionsFilterIsDisplayed() {
+    programsPage.checkAdminActionsFilterIsDisplayed();
   }
 
 }

--- a/src/test/java/io/meeds/qa/ui/steps/UserProfileSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/UserProfileSteps.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import io.meeds.qa.ui.pages.KudosPage;
 import io.meeds.qa.ui.pages.UserProfilePage;
-import io.meeds.qa.ui.utils.Utils;
 
 public class UserProfileSteps {
 
@@ -203,15 +202,8 @@ public class UserProfileSteps {
     userProfilePage.uploadProfileAvatar(fileName);
   }
 
-  public boolean wasMyPointIncreased(int myPointBeforeKudos) {
-    int retry = 5;
-    int index = 0;
-    // Retry at most 3 times until Gamification Points are increased
-    while (userProfilePage.getMyWeeklyPoint() <= myPointBeforeKudos && index++ < retry) {
-      userProfilePage.waitFor(3).seconds();
-      Utils.refreshPage();
-    }
-    return index < retry;
+  public void checkMyPointIncrease(int originalWeeklyPoint) {
+    userProfilePage.checkMyPointIncrease(originalWeeklyPoint);
   }
 
 }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
@@ -53,9 +53,10 @@ public class AchievementsStepDefinition {
     achievementsSteps.checkThatAchievementIsDisplayed(actionTitle, Long.parseLong(times));
   }
 
-  @Then("^The achievement '(.*)' is displayed '(.*)' times when enabling '(.*)' switch button$")
-  public void checkThatAchievementIsDisplayedWithSwitchEnabled(String actionTitle, String times, String switchButtonName) {
-    achievementsSteps.checkThatAchievementIsDisplayedWithSwitchEnabled(actionTitle, Long.parseLong(times), switchButtonName);
+  @Then("^The achievement '(.*)' is displayed '(.*)' times when enabling program owner view for '(.*)' random program$")
+  public void checkThatAchievementIsDisplayedWithProgramOwnerView(String actionTitle, String times, String randomProgramSuffix) {
+    String programName = Serenity.sessionVariableCalled("programName" + randomProgramSuffix);
+    achievementsSteps.checkThatAchievementIsDisplayedWithProgramOwnerView(actionTitle, Long.parseLong(times), programName);
   }
 
   @Then("^The achievement '(.*)' is displayed '(.*)' times for '(.*)' random program$")

--- a/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
@@ -53,6 +53,12 @@ public class AchievementsStepDefinition {
     achievementsSteps.checkThatAchievementIsDisplayed(actionTitle, Long.parseLong(times));
   }
 
+  @Then("^The achievement '(.*)' is displayed '(.*)' times for '(.*)' random program$")
+  public void checkThatAchievementIsDisplayed(String actionTitle, String times, String randomProgramSuffix) {
+    String programName = Serenity.sessionVariableCalled("programName" + randomProgramSuffix);
+    achievementsSteps.checkThatAchievementIsDisplayed(actionTitle, Long.parseLong(times), programName);
+  }
+
   @And("^I filter achievements using '(.*)' program$")
   public void filterAchievementByProgram(String programTitle) {
     achievementsSteps.filterAchievementByProgram(programTitle);

--- a/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/AchievementsStepDefinition.java
@@ -53,6 +53,11 @@ public class AchievementsStepDefinition {
     achievementsSteps.checkThatAchievementIsDisplayed(actionTitle, Long.parseLong(times));
   }
 
+  @Then("^The achievement '(.*)' is displayed '(.*)' times when enabling '(.*)' switch button$")
+  public void checkThatAchievementIsDisplayedWithSwitchEnabled(String actionTitle, String times, String switchButtonName) {
+    achievementsSteps.checkThatAchievementIsDisplayedWithSwitchEnabled(actionTitle, Long.parseLong(times), switchButtonName);
+  }
+
   @Then("^The achievement '(.*)' is displayed '(.*)' times for '(.*)' random program$")
   public void checkThatAchievementIsDisplayed(String actionTitle, String times, String randomProgramSuffix) {
     String programName = Serenity.sessionVariableCalled("programName" + randomProgramSuffix);

--- a/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.lang3.StringUtils;
 
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.meeds.qa.ui.steps.GenericSteps;
@@ -134,6 +135,7 @@ public class GenericStepDefinitions {
   }
 
   @When("I wait '{int}' seconds")
+  @And("I wait for '{int}' seconds")
   public void waitInSeconds(int seconds) {
     genericSteps.waitInSeconds(seconds);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/ProgramsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/ProgramsStepDefinition.java
@@ -225,14 +225,19 @@ public class ProgramsStepDefinition {
     programsSteps.announceChallenge(challengeTitle, announcementMessage);
   }
 
-  @Then("Actions Filter dropdown is not displayed")
-  public void checkActionsFilterIsNotDisplayed() {
-    programsSteps.checkActionsFilterIsNotDisplayed();
-  }
-
   @Then("Actions Filter dropdown is displayed")
   public void checkActionsFilterIsDisplayed() {
     programsSteps.checkActionsFilterIsDisplayed();
+  }
+
+  @Then("Admin Actions Filter dropdown is not displayed")
+  public void checkAdminActionsFilterIsNotDisplayed() {
+    programsSteps.checkAdminActionsFilterIsNotDisplayed();
+  }
+  
+  @Then("Admin Actions Filter dropdown is displayed")
+  public void checkAdminActionsFilterIsDisplayed() {
+    programsSteps.checkAdminActionsFilterIsDisplayed();
   }
 
 }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/UserProfileStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/UserProfileStepDefinition.java
@@ -58,10 +58,8 @@ public class UserProfileStepDefinition {
 
   @Then("My points augmented")
   public void checkMyPointIncrease() {
-    int myPointBeforeKudos = Serenity.sessionVariableCalled("myPointBeforeKudos");
-    assertThat(userProfileSteps.wasMyPointIncreased(myPointBeforeKudos)).as("The points did not increase. Old Value = "
-        + myPointBeforeKudos)
-                                                                        .isTrue();
+    int originalWeeklyPoint = Serenity.sessionVariableCalled("originalWeeklyPoint");
+    userProfileSteps.checkMyPointIncrease(originalWeeklyPoint);
   }
 
   @Then("^Updated Profile Contact instantMessaging is displayed$")
@@ -88,8 +86,8 @@ public class UserProfileStepDefinition {
 
   @When("^I check my points$")
   public void getMyWeeklyPoint() {
-    int myPointBeforeKudos = userProfileSteps.getMyWeeklyPoint();
-    Serenity.setSessionVariable("myPointBeforeKudos").to(myPointBeforeKudos);
+    int originalWeeklyPoint = userProfileSteps.getMyWeeklyPoint();
+    Serenity.setSessionVariable("originalWeeklyPoint").to(originalWeeklyPoint);
   }
 
   @Then("I go to Received Kudos")

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -219,8 +219,7 @@ Feature: Achievements
     Then The achievement 'Join space' is displayed '1' times
     And The switch button 'Display achievements from programs you host' is displayed
 
-    When I enable the switch button 'Display achievements from programs you host'
-    Then The achievement 'Join space' is displayed '2' times
+    Then The achievement 'Join space' is displayed '2' times when enabling 'Display achievements from programs you host' switch button
 
   Scenario: Cancel Activity changes the Achievement as Rejected
     Given I am authenticated as 'admin' random user
@@ -466,6 +465,11 @@ Feature: Achievements
 
     When I login as 'eighthachievement' random user
     And I go to the random space
+    And I go to 'Contributions' application
+    And I select engagement Achievements tab
+
+    Then Achievement for 'Cancel Space Join' is accepted
+
     And I go to spaces page
     And I search for the random space
     And I leave found space

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -1,3 +1,4 @@
+@gamification
 @achievements
 Feature: Achievements
 
@@ -134,8 +135,6 @@ Feature: Achievements
     And I select engagement Achievements tab
     Then Achievement for 'Receive kudos' is canceled
 
-  # Unstable Test case
-  @ignored
   Scenario: Achievements listing for program owner/space host
     Given I am authenticated as 'admin' random user
     And I create the random space if not existing

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -52,12 +52,19 @@ Feature: Achievements
     And I publish the activity
 
     And I login as 'fisrtachievement' random user
+
+    And I go to My Profile page
+    And I check my points
+
     When I go to the random space
     And I send in the activity 'Achievements - Kudos Post activity' a kudos message 'Achievements - kudos activity comment to cancel'
 
     And I go to 'Contributions' application
     When I select engagement Achievements tab
     Then Achievement for 'Send kudos' is accepted
+
+    When I go to My Profile page
+    Then My points augmented
 
     And I go to the random space
     When In activity 'Achievements - Kudos Post activity' I cancel the sent kudos comment 'Achievements - kudos activity comment to cancel'
@@ -180,9 +187,8 @@ Feature: Achievements
     When I login as 'admin' random user
     And I go to 'Contributions' application
     And I select engagement Achievements tab
-    And I filter achievements using 'Test Program Host' random program
 
-    Then The achievement 'Join space' is displayed '2' times
+    Then The achievement 'Join space' is displayed '2' times for 'Test Program Host' random program
 
     When I go to the random space
     And I click on 'Members' space menu tab
@@ -206,6 +212,7 @@ Feature: Achievements
     Then Actions Filter dropdown is displayed
 
     When I select engagement Achievements tab
+    And I filter achievements using 'Test Program Host' random program
     Then The achievement 'Join space' is displayed '1' times
     And The switch button 'Display achievements from programs you host' is displayed
 

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -176,13 +176,15 @@ Feature: Achievements
     And I go to the random space
     And I go to 'Contributions' application
     When I open 'Test Program Host' random program card
-    Then Actions Filter dropdown is not displayed
+    Then Actions Filter dropdown is displayed
+    And Admin Actions Filter dropdown is not displayed
 
     And I login as 'sixthachievement' random user
     And I go to the random space
     And I go to 'Contributions' application
     When I open 'Test Program Host' random program card
-    Then Actions Filter dropdown is not displayed
+    Then Actions Filter dropdown is displayed
+    And Admin Actions Filter dropdown is not displayed
 
     When I login as 'admin' random user
     And I go to 'Contributions' application
@@ -210,6 +212,7 @@ Feature: Achievements
 
     When I open 'Test Program Host' random program card
     Then Actions Filter dropdown is displayed
+    And Admin Actions Filter dropdown is displayed
 
     When I select engagement Achievements tab
     And I filter achievements using 'Test Program Host' random program

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -190,7 +190,7 @@ Feature: Achievements
     And I go to 'Contributions' application
     And I select engagement Achievements tab
 
-    Then The achievement 'Join space' is displayed '2' times for 'Test Program Host' random program
+    Then The achievement 'Join space' is displayed '2' times when enabling program owner view for 'Test Program Host' random program
 
     When I go to the random space
     And I click on 'Members' space menu tab
@@ -202,10 +202,7 @@ Feature: Achievements
     And I go to 'Contributions' application
     And I select engagement Achievements tab
     Then The achievement 'Join space' is displayed '1' times
-    And The switch button 'Display achievements from programs you host' is displayed
-
-    When I enable the switch button 'Display achievements from programs you host'
-    Then The achievement 'Join space' is displayed '0' times
+    And The switch button 'Display achievements from programs you host' is not displayed
 
     When I login as 'fifthachievement' random user
     And I go to 'Contributions' application
@@ -219,7 +216,7 @@ Feature: Achievements
     Then The achievement 'Join space' is displayed '1' times
     And The switch button 'Display achievements from programs you host' is displayed
 
-    Then The achievement 'Join space' is displayed '2' times when enabling 'Display achievements from programs you host' switch button
+    Then The achievement 'Join space' is displayed '2' times when enabling program owner view for 'Test Program Host' random program
 
   Scenario: Cancel Activity changes the Achievement as Rejected
     Given I am authenticated as 'admin' random user

--- a/src/test/resources/features/Gamification/Challenges.feature
+++ b/src/test/resources/features/Gamification/Challenges.feature
@@ -1,6 +1,6 @@
 @gamification
-@challenge
-Feature: Challenges
+@actions
+Feature: Actions
 
   Scenario: Announce a challenge
     Given I am authenticated as 'admin' random user

--- a/src/test/resources/features/Gamification/ProgramCreation.feature
+++ b/src/test/resources/features/Gamification/ProgramCreation.feature
@@ -1,3 +1,4 @@
+@gamification
 @programs
 Feature: Programs
 

--- a/src/test/resources/features/Gamification/TopProgramsWidget.feature
+++ b/src/test/resources/features/Gamification/TopProgramsWidget.feature
@@ -45,10 +45,9 @@ Feature: Programs should be displayed in Top Programs in sorted way
 
     When I login as 'admin' random user
     And I go to 'Contributions' application
-    And I select engagement Challenges tab
+    And I select engagement Actions tab
     And I update the 'thirtyone' random challenge with
       | points | 9999 |
-    And I search the 'thirtyone' random challenge
     Then The 'thirtyone' challenge is displayed with '9999' points
 
     When I login as 'thirtyone' random user

--- a/src/test/resources/features/Gamification/ruleScore.feature
+++ b/src/test/resources/features/Gamification/ruleScore.feature
@@ -4,20 +4,6 @@
 Feature: Check the rules score increase
   for different type of activity on the plf
 
-  Scenario: Send a Kudos
-    Given I am authenticated as 'admin' if random users doesn't exists
-      | first  |
-      | second  |
-    And I create the first random user if not existing, no wait
-    And I create the second random user if not existing
-    When I login as 'first' random user
-    And I go to My Profile page
-    And I check my points
-    And I go to the second user profile
-    And I send kudos with message 'rule score kudos'
-    When I go to My Profile page
-    Then My points augmented
-
   # Instable Use Case
   @skip
   Scenario: Receive a connection request


### PR DESCRIPTION
Prior to this change, the Achivements are computed asynchronously and thus, some tests fails due to achievements status change operation not completed yet. This change will add a retry mechanism to make tests more stable independantly from Server performances.