### PR TITLE
fix: Modify changed labels on Crowdin for Contribution Center

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/RulePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/RulePage.java
@@ -215,7 +215,7 @@ public class RulePage extends GenericPage {
   }
 
   private ElementFacade addActionButton() {
-    return findByXPathOrCSS("//*[@id = 'engagementCenterProgramDetail']//*[contains(text(), 'Add Action') or contains(text(), 'Add incentive')]//ancestor::button");
+    return findByXPathOrCSS("//*[@id = 'engagementCenterProgramDetail']//*[contains(text(), 'Add Action') or contains(text(), 'Add action')]//ancestor::button");
   }
 
   private ButtonElementFacade ruleEventsMenuItem(String eventName) {

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -15,7 +15,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Send kudos'
     And I add rule random description
@@ -99,7 +99,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Send kudos'
     And I add rule random description
@@ -171,7 +171,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Join space'
     And I add rule random description
@@ -259,7 +259,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Join space'
     And I add rule random description
@@ -376,7 +376,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    When I click on 'Add incentive' button
+    When I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Post activity in a space'
     And I add rule random description
@@ -425,7 +425,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    When I click on 'Add incentive' button
+    When I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Comment activity in space'
     And I add rule random description
@@ -489,7 +489,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    When I click on 'Add incentive' button
+    When I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Like activity in space'
     And I add rule random description
@@ -551,7 +551,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    When I click on 'Add incentive' button
+    When I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Like stream comment in space'
     And I add rule random description
@@ -614,7 +614,7 @@ Feature: Achievements
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Cancel Space Join'
     And I add rule random description

--- a/src/test/resources/features/Gamification/Actions.feature
+++ b/src/test/resources/features/Gamification/Actions.feature
@@ -14,7 +14,7 @@ Feature: Actions
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
 
     Then The button 'Next' is disabled in drawer
@@ -90,7 +90,7 @@ Feature: Actions
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
 
     When I enter the rule title 'Challenge to disable'
@@ -141,7 +141,7 @@ Feature: Actions
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Challenge To Cancel'
     And I add rule random description
@@ -186,7 +186,7 @@ Feature: Actions
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Announce activity to delete'
     And I add rule random description
@@ -230,7 +230,7 @@ Feature: Actions
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Top challenge'
     And I add rule random description

--- a/src/test/resources/features/Gamification/Programs.feature
+++ b/src/test/resources/features/Gamification/Programs.feature
@@ -97,7 +97,7 @@ Feature: Programs
     Then Confirmation message is displayed 'New program created successfully'
 
     When I close the notification
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     When I enter the rule title 'Program Translation Action'
 
@@ -160,7 +160,7 @@ Feature: Programs
 
     Then The program is displayed with specific cover
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     When I enter the rule title 'Program With Image Action'
     When I add rule random description
@@ -218,7 +218,7 @@ Feature: Programs
     Then success message is displayed
     When I close the notification
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     When I enter the rule title 'Internal users action'
     When I add rule random description
@@ -289,7 +289,7 @@ Feature: Programs
     When I close the notification
     Then The button 'Activate the program' is not displayed
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     Then The button 'Next' is disabled
     When I enter the rule title 'Program activation test'
@@ -320,7 +320,7 @@ Feature: Programs
     And I close the notification
 
     Then The button 'Activate the program' is not displayed
-    And The message 'No active incentives' is displayed
+    And The message 'No active action' is displayed
 
     When I filter program actions by value 'ALL'
     And I edit program action 'Program activation test'
@@ -335,7 +335,7 @@ Feature: Programs
     And I close the notification
 
     Then The button 'Activate the program' is not displayed
-    And The message 'No active incentives' is not displayed
+    And The message 'No active action' is not displayed
 
     When I delete program action 'Program activation test'
 

--- a/src/test/resources/features/Gamification/Rules.feature
+++ b/src/test/resources/features/Gamification/Rules.feature
@@ -14,7 +14,7 @@ Feature: Rules
     And I add an audience space
     And I save the program details
 
-    And I click on 'Add incentive' button
+    And I click on 'Add action' button
     And I wait for drawer to open
     And I enter the rule title 'Receive kudos'
     And I add rule random description


### PR DESCRIPTION
Prior to this change, the Test cases which depends on Contribution Center labels fails due to changed labels synchronized from Crowdin. This change will use the new labels.