### PR TITLE
feat: Add Main Settings UI Tests - Meeds-io/MIPs#76

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
@@ -112,6 +112,10 @@ public class GenericPage extends BasePageImpl {
     findByXPathOrCSS("//*[contains(@class, 'v-alert')]//*[contains(@class, 'success')]").assertVisible();
   }
 
+  public void checkInformationMessageDisplayed() {
+    findByXPathOrCSS("//*[contains(@class, 'v-alert')]//*[contains(@class, 'info')]").assertVisible();
+  }
+
   public void checkSwitchButtonNotDisplayed(String buttonName) {
     findByXPathOrCSS(String.format("//*[contains(@class, 'v-input--switch')]/parent::*//*[contains(text(), '%s')]",
                                    buttonName)).assertNotVisible();

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -229,7 +229,7 @@ public class HomePage extends GenericPage {
   }
 
   public void goToMainSettings() {
-    goToAdministrationPage("/generalSettings");
+    goToAdministrationPage("/generalSettings", true);
   }
 
   public void goToAppCenterAdminSetupPage() {
@@ -480,7 +480,11 @@ public class HomePage extends GenericPage {
   }
 
   private void goToAdministrationPage(String uri) {
-    if (!StringUtils.contains(getDriver().getCurrentUrl(), uri)) {
+    goToAdministrationPage(uri, false);
+  }
+
+  private void goToAdministrationPage(String uri, boolean forceRefresh) {
+    if (forceRefresh || !StringUtils.contains(getDriver().getCurrentUrl(), uri)) {
       accessToAdministrationMenu();
       waitFor(50).milliseconds();
       findByXPathOrCSS(String.format("//*[@id = 'AdministrationHamburgerNavigation']//a[contains(@href, '%s')]", uri)).click();

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -223,9 +223,13 @@ public class HomePage extends GenericPage {
   public void goToAddGroups() {
     goToAdministrationPage("/groupsManagement");
   }
-
+  
   public void goToAddUser() {
     goToAdministrationPage("/usersManagement");
+  }
+
+  public void goToMainSettings() {
+    goToAdministrationPage("/generalSettings");
   }
 
   public void goToAppCenterAdminSetupPage() {

--- a/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
@@ -19,6 +19,7 @@ package io.meeds.qa.ui.pages;
 
 import static io.meeds.qa.ui.utils.Utils.retryOnCondition;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -217,8 +218,10 @@ public class LoginPage extends GenericPage implements IsHidden {
     int brandingLogoElementWidth = brandingLogoElement.getRect().getWidth();
     int brandingLogoElementHeight = brandingLogoElement.getRect().getHeight();
 
-    assertEquals((long) (windowHeight - brandingLogoElementHeight - windowHeight * 0.03d), brandingLogoElementTop);
-    assertEquals((long) (windowWidth - brandingLogoElementWidth - windowWidth * 0.03d), brandingLogoElementLeft);
+    long diffY = Math.abs(((long) (windowHeight - brandingLogoElementHeight - windowHeight * 0.03d)) - brandingLogoElementTop);
+    long diffX = Math.abs(((long) (windowWidth - brandingLogoElementWidth - windowWidth * 0.03d)) - brandingLogoElementLeft);
+    assertTrue(diffY <= 2);
+    assertTrue(diffX <= 2);
   }
 
   private boolean returnError(String message, boolean throwException) {

--- a/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/LoginPage.java
@@ -152,6 +152,14 @@ public class LoginPage extends GenericPage implements IsHidden {
     usernameInputElement().assertVisible();
   }
 
+  public void registerLinkIsDisplayed() {
+    registerLink().isVisible();
+  }
+
+  public void registerLinkIsNotDisplayed() {
+    registerLink().isNotVisible();
+  }
+
   private void logout(int max) {
     logout(1, max); // recursive method
   }
@@ -233,6 +241,10 @@ public class LoginPage extends GenericPage implements IsHidden {
 
   private ElementFacade loginButtonElement() {
     return findButtonByXPathOrCSS("//*[contains(@class, 'loginButton')]//button");
+  }
+
+  private ElementFacade registerLink() {
+    return findButtonByXPathOrCSS("//a[@href = '/portal/register']");
   }
 
   private TextBoxElementFacade passwordInputElement() {

--- a/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
@@ -29,23 +29,14 @@ public class MainSettingsPage extends GenericPage {
   }
 
   public void goToLoginCustomization() {
-    if (backToMainButton().isCurrentlyVisible()) {
-      goBackToMainSettings();
-    }
     loginCustomizationEditButton().click();
   }
 
   public void goToBrandingCustomization() {
-    if (backToMainButton().isCurrentlyVisible()) {
-      goBackToMainSettings();
-    }
     brandingCustomizationEditButton().click();
   }
 
   public void goToAccessCustomization() {
-    if (backToMainButton().isCurrentlyVisible()) {
-      goBackToMainSettings();
-    }
     accessCustomizationEditButton().click();
   }
 

--- a/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
@@ -1,0 +1,254 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.qa.ui.pages;
+
+import org.openqa.selenium.WebDriver;
+
+import io.meeds.qa.ui.elements.ElementFacade;
+import io.meeds.qa.ui.elements.TextBoxElementFacade;
+
+public class MainSettingsPage extends GenericPage {
+
+  public MainSettingsPage(WebDriver driver) {
+    super(driver);
+  }
+
+  public void goToLoginCustomization() {
+    if (backToMainButton().isCurrentlyVisible()) {
+      goBackToMainSettings();
+    }
+    loginCustomizationEditButton().click();
+  }
+
+  public void goToBrandingCustomization() {
+    if (backToMainButton().isCurrentlyVisible()) {
+      goBackToMainSettings();
+    }
+    brandingCustomizationEditButton().click();
+  }
+
+  public void goToAccessCustomization() {
+    if (backToMainButton().isCurrentlyVisible()) {
+      goBackToMainSettings();
+    }
+    accessCustomizationEditButton().click();
+  }
+
+  public void goBackToMainSettings() {
+    backToMainButton().click();
+  }
+
+  public void checkLoginCustomization() {
+    loginBackgroundButton().assertVisible();
+    loginTitleInput().assertVisible();
+    loginSubTitleInput().assertVisible();
+    cancelButton().assertVisible();
+    cancelButton().assertEnabled();
+    applyButton().assertVisible();
+    applyButton().assertDisabled();
+    backToMainButton().assertVisible();
+  }
+
+  public void checkBrandingCustomization() {
+    brandingCompanyNameInput().assertVisible();
+    brandingLogoInput().assertVisible();
+    brandingFaviconInput().assertVisible();
+    brandingPrimaryColorInput().assertVisible();
+    brandingSecondaryColorInput().assertVisible();
+    brandingTerciaryColorInput().assertVisible();
+    cancelButton().assertVisible();
+    cancelButton().assertEnabled();
+    applyButton().assertVisible();
+    applyButton().assertDisabled();
+    backToMainButton().assertVisible();
+  }
+
+  public void checkAccessCustomization() {
+    accessTypeOpenInput().assertVisible();
+    accessTypeRestrictedInput().assertVisible();
+    accessEditDefaultSpaceButton().assertVisible();
+    accessExternalUserOpenSwitchButton().assertVisible();
+    accessExternalUserRestrictedSwitchButton().assertVisible();
+    cancelButton().assertVisible();
+    cancelButton().assertEnabled();
+    applyButton().assertVisible();
+    applyButton().assertDisabled();
+    backToMainButton().assertVisible();
+  }
+
+  public void selectOpenAccessCustomization() {
+    accessTypeOpenInput().click();
+  }
+
+  public void selectRestrictedAccessCustomization() {
+    accessTypeRestrictedInput().click();
+  }
+
+  public void switchRestrictedExternalUsers() {
+    accessExternalUserRestrictedSwitchButton().click();
+  }
+
+  public void checkApplyButtonIsEnabled() {
+    applyButton().assertEnabled();
+  }
+
+  public void checkApplyButtonIsDisabled() {
+    applyButton().assertDisabled();
+  }
+
+  public void cancelCustomization() {
+    cancelButton().click();
+  }
+
+  public void applyCustomization() {
+    if (applyButton().isEnabled()) {
+      applyButton().click();
+    }
+  }
+
+  public void setLoginTitle(String title) {
+    loginTitleInput().setTextValue(title);
+  }
+
+  public void setLoginSubTitle(String subtitle) {
+    loginSubTitleInput().setTextValue(subtitle);
+  }
+
+  public void selectAccessDefaultSpace(String randomSpaceName) {
+    accessEditDefaultSpaceButton().click();
+    waitForDrawerToOpen();
+    while (accessDefaultSpaceDeleteIcon().isVisible()) {
+      accessDefaultSpaceDeleteIcon().click();
+    }
+    mentionInField(accessDefaultSpaceInput(), randomSpaceName, 3);
+    clickDrawerButton("Apply");
+    waitForDrawerToClose();
+  }
+
+  public void checkRestrictedExternalUserSwitchButtonIsDisabled() {
+    accessExternalUserOpenSwitchButtonInput().assertEnabled();
+    accessExternalUserRestrictedSwitchButtonInput().assertDisabled();
+  }
+
+  public void checkOpenExternalUserSwitchButtonIsDisabled() {
+    accessExternalUserOpenSwitchButtonInput().assertDisabled();
+    accessExternalUserRestrictedSwitchButtonInput().assertEnabled();
+  }
+
+  public void checkAccessDefaultSpacesCount(int count) {
+    findByXPathOrCSS(String.format("//*[@id='generalSettings']//*[contains(text(), 'default space')]//ancestor::*[contains(@class, 'v-list-item')]//*[contains(text(), '%s selected space')]",
+                                   count)).assertVisible();
+  }
+
+  private ElementFacade brandingCustomizationEditButton() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(@class, 'fa-edit')])[1]");
+  }
+
+  private ElementFacade loginCustomizationEditButton() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(@class, 'fa-edit')])[2]");
+  }
+
+  private ElementFacade accessCustomizationEditButton() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(@class, 'fa-edit')])[3]");
+  }
+
+  private TextBoxElementFacade brandingCompanyNameInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name='companyName']");
+  }
+
+  private TextBoxElementFacade brandingLogoInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@id='logoFileInput']//ancestor::*[contains(@class, 'file-selector')]//ancestor::*[contains(@class, 'v-image')]");
+  }
+
+  private TextBoxElementFacade brandingFaviconInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@id='faviconFileInput']//ancestor::*[contains(@class, 'file-selector')]//ancestor::*[contains(@class, 'v-image')]");
+  }
+
+  private ElementFacade brandingPrimaryColorInput() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(text(), 'Theme colors')]/parent::*//*[contains(@class, 'v-card--link')])[1]");
+  }
+
+  private ElementFacade brandingSecondaryColorInput() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(text(), 'Theme colors')]/parent::*//*[contains(@class, 'v-card--link')])[2]");
+  }
+
+  private ElementFacade brandingTerciaryColorInput() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//*[contains(text(), 'Theme colors')]/parent::*//*[contains(@class, 'v-card--link')])[3]");
+  }
+
+  private ElementFacade cancelButton() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//button//*[contains(text(), 'Cancel')]//ancestor::button");
+  }
+
+  private ElementFacade applyButton() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//button//*[contains(text(), 'Apply')]//ancestor::button");
+  }
+
+  private ElementFacade backToMainButton() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//*[contains(@class, 'fa-arrow-left')]");
+  }
+
+  private TextBoxElementFacade loginTitleInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginTitle']");
+  }
+
+  private TextBoxElementFacade loginSubTitleInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginSubtitle']");
+  }
+
+  private ElementFacade loginBackgroundButton() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//button//*[contains(text(), 'Add background')]");
+  }
+
+  private ElementFacade accessTypeOpenInput() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//input[@value = 'OPEN' and @type = 'radio']//ancestor::*[contains(@class, 'v-radio')]");
+  }
+
+  private ElementFacade accessTypeRestrictedInput() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//input[@value = 'RESTRICTED' and @type = 'radio']//ancestor::*[contains(@class, 'v-radio')]");
+  }
+
+  private ElementFacade accessExternalUserOpenSwitchButtonInput() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//input[@role = 'switch' and @type = 'checkbox'])[1]");
+  }
+
+  private ElementFacade accessExternalUserRestrictedSwitchButtonInput() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//input[@role = 'switch' and @type = 'checkbox'])[2]");
+  }
+
+  private ElementFacade accessExternalUserOpenSwitchButton() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//input[@role = 'switch' and @type = 'checkbox'])[1]//ancestor::*[contains(@class, 'v-input--switch')]");
+  }
+
+  private ElementFacade accessExternalUserRestrictedSwitchButton() {
+    return findByXPathOrCSS("(//*[@id='generalSettings']//input[@role = 'switch' and @type = 'checkbox'])[2]//ancestor::*[contains(@class, 'v-input--switch')]");
+  }
+
+  private ElementFacade accessEditDefaultSpaceButton() {
+    return findByXPathOrCSS("//*[@id='generalSettings']//*[contains(text(), 'default space')]//ancestor::*[contains(@class, 'v-list-item')]//*[contains(@class, 'fa-edit')]");
+  }
+
+  private TextBoxElementFacade accessDefaultSpaceInput() {
+    return findTextBoxByXPathOrCSS("//*[@id='defaultSpacesInput']//input");
+  }
+
+  private TextBoxElementFacade accessDefaultSpaceDeleteIcon() {
+    return findTextBoxByXPathOrCSS("//*[contains(@class, 'identitySuggesterItem')]//button[contains(@class, 'close')]");
+  }
+
+}

--- a/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/MainSettingsPage.java
@@ -122,10 +122,16 @@ public class MainSettingsPage extends GenericPage {
   }
 
   public void setLoginTitle(String title) {
+    if (clearLoginTitleButton().isVisible()) {
+      clearLoginTitleButton().click();
+    }
     loginTitleInput().setTextValue(title);
   }
 
   public void setLoginSubTitle(String subtitle) {
+    if (clearSubTitleTitleButton().isVisible()) {
+      clearSubTitleTitleButton().click();
+    }
     loginSubTitleInput().setTextValue(subtitle);
   }
 
@@ -204,11 +210,19 @@ public class MainSettingsPage extends GenericPage {
   }
 
   private TextBoxElementFacade loginTitleInput() {
-    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginTitle']");
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//input[@name='loginTitle']");
+  }
+
+  private TextBoxElementFacade clearLoginTitleButton() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginTitle']//ancestor::*[contains(@class, 'v-input')]//*[contains(@class, 'fa-times')]");
   }
 
   private TextBoxElementFacade loginSubTitleInput() {
-    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginSubtitle']");
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//input[@name='loginSubtitle']");
+  }
+
+  private TextBoxElementFacade clearSubTitleTitleButton() {
+    return findTextBoxByXPathOrCSS("//*[@id='generalSettings']//*[@name = 'loginSubtitle']//ancestor::*[contains(@class, 'v-input')]//*[contains(@class, 'fa-times')]");
   }
 
   private ElementFacade loginBackgroundButton() {

--- a/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
@@ -21,6 +21,7 @@ import static io.meeds.qa.ui.utils.Utils.waitForLoading;
 import static io.meeds.qa.ui.utils.Utils.waitForPageLoading;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 
 import io.meeds.qa.ui.elements.ButtonElementFacade;
@@ -481,6 +482,24 @@ public class ManageSpacesPage extends GenericPage {
     moveApplication(appName, "Move before");
   }
 
+  public void openSpaceInvitationDrawer() {
+    inviteUserButtonElement().click();
+    waitForDrawerToOpen();
+  }
+
+  public void inviteEmailAsSpaceMember(String email) {
+    inviteUserInputElement().setTextValue(email);
+    inviteUserInputElement().sendKeys(Keys.ENTER);
+  }
+
+  public void emailIsListedInInvitationList(String email, String status) {
+    inviteEmailStatusElement(email, status).assertVisible();
+  }
+
+  public void emailIsNotListedInInvitationList(String email) {
+    inviteEmailStatusElement(email).assertNotVisible();
+  }
+
   private String moveApplication(int appPosition, String actionName) {
     String appTitle = spaceSettingAppTitle(appPosition).getText();
     spaceSettingAppMenu(appPosition).click();
@@ -627,11 +646,22 @@ public class ManageSpacesPage extends GenericPage {
   }
 
   private ElementFacade inviteUserButtonElement() {
-    return findByXPathOrCSS("//*[@class='uiIconInviteUser ms-2 me-1']");
+    return findByXPathOrCSS("//*[contains(@class, 'inviteUserToSpaceButton')]");
   }
 
   private TextBoxElementFacade inviteUserInputElement() {
     return findTextBoxByXPathOrCSS("(//div[@name='inviteMembers']//input)[1]");
+  }
+
+  private ElementFacade inviteEmailStatusElement(String email, String status) {
+    return findByXPathOrCSS(String.format("//*[contains(text(), '%s')]/ancestor::*[contains(@class, 'externalList')]//*[contains(text(), '%s')]",
+                                          email,
+                                          status));
+  }
+
+  private ElementFacade inviteEmailStatusElement(String email) {
+    return findByXPathOrCSS(String.format("//*[contains(text(), '%s')]/ancestor::*[contains(@class, 'externalList')]",
+                                          email));
   }
 
   private ElementFacade moveAfterAppButtonElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
@@ -172,6 +172,10 @@ public class GenericSteps {
     genericPage.checkSuccessMessageDisplayed();
   }
 
+  public void checkInformationMessageDisplayed() {
+    genericPage.checkInformationMessageDisplayed();
+  }
+
   public void waitInSeconds(int seconds) {
     genericPage.waitFor(seconds).seconds();
   }

--- a/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
@@ -159,6 +159,10 @@ public class HomeSteps {
     homePage.goToAddUser();
   }
 
+  public void goToMainSettings() {
+    homePage.goToMainSettings();
+  }
+
   public void goToAppCenterAdminSetupPage() {
     homePage.goToAppCenterAdminSetupPage();
   }

--- a/src/test/java/io/meeds/qa/ui/steps/LoginSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/LoginSteps.java
@@ -82,12 +82,10 @@ public class LoginSteps {
   }
 
   public void checkRegisterLinkIsDisplayed() {
-    loginPage.checkLoginPageDisplay();
     loginPage.registerLinkIsDisplayed();
   }
 
   public void checkRegisterLinkIsNotDisplayed() {
-    loginPage.checkLoginPageDisplay();
     loginPage.registerLinkIsNotDisplayed();
   }
 

--- a/src/test/java/io/meeds/qa/ui/steps/LoginSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/LoginSteps.java
@@ -81,4 +81,14 @@ public class LoginSteps {
     loginPage.waitForUsernameInputDisplay(retries);
   }
 
+  public void checkRegisterLinkIsDisplayed() {
+    loginPage.checkLoginPageDisplay();
+    loginPage.registerLinkIsDisplayed();
+  }
+
+  public void checkRegisterLinkIsNotDisplayed() {
+    loginPage.checkLoginPageDisplay();
+    loginPage.registerLinkIsNotDisplayed();
+  }
+
 }

--- a/src/test/java/io/meeds/qa/ui/steps/MainSettingsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/MainSettingsSteps.java
@@ -1,0 +1,108 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package io.meeds.qa.ui.steps;
+
+import io.meeds.qa.ui.pages.MainSettingsPage;
+
+public class MainSettingsSteps {
+
+  private MainSettingsPage mainSettingsPage;
+
+  public void goToAccessCustomization() {
+    mainSettingsPage.goToAccessCustomization();
+  }
+
+  public void goToBrandingCustomization() {
+    mainSettingsPage.goToBrandingCustomization();
+  }
+
+  public void goToLoginCustomization() {
+    mainSettingsPage.goToLoginCustomization();
+  }
+
+  public void goBackToMainSettings() {
+    mainSettingsPage.goBackToMainSettings();
+  }
+
+  public void checkAccessCustomization() {
+    mainSettingsPage.checkAccessCustomization();
+  }
+
+  public void checkBrandingCustomization() {
+    mainSettingsPage.checkBrandingCustomization();
+  }
+
+  public void checkLoginCustomization() {
+    mainSettingsPage.checkLoginCustomization();
+  }
+
+  public void checkApplyButtonIsEnabled() {
+    mainSettingsPage.checkApplyButtonIsEnabled();
+  }
+
+  public void checkApplyButtonIsDisabled() {
+    mainSettingsPage.checkApplyButtonIsDisabled();
+  }
+
+  public void cancelCustomization() {
+    mainSettingsPage.cancelCustomization();
+  }
+
+  public void applyCustomization() {
+    mainSettingsPage.applyCustomization();
+  }
+
+  public void selectOpenAccessCustomization() {
+    mainSettingsPage.selectOpenAccessCustomization();
+  }
+
+  public void selectRestrictedAccessCustomization() {
+    mainSettingsPage.selectRestrictedAccessCustomization();
+  }
+
+  public void switchRestrictedExternalUsers() {
+    mainSettingsPage.switchRestrictedExternalUsers();
+  }
+
+  public void setLoginTitle(String title) {
+    mainSettingsPage.setLoginTitle(title);
+  }
+
+  public void setLoginSubTitle(String subtitle) {
+    mainSettingsPage.setLoginSubTitle(subtitle);
+  }
+
+  public void checkAccessDefaultSpacesCount(int count) {
+    mainSettingsPage.checkAccessDefaultSpacesCount(count);
+  }
+
+  public void selectAccessDefaultSpace(String randomSpaceName) {
+    mainSettingsPage.selectAccessDefaultSpace(randomSpaceName);
+  }
+
+  public void checkRestrictedExternalUserSwitchButtonIsDisabled() {
+    mainSettingsPage.checkRestrictedExternalUserSwitchButtonIsDisabled();
+  }
+
+  public void checkOpenExternalUserSwitchButtonIsDisabled() {
+    mainSettingsPage.checkOpenExternalUserSwitchButtonIsDisabled();
+  }
+
+}

--- a/src/test/java/io/meeds/qa/ui/steps/ManageSpaceSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/ManageSpaceSteps.java
@@ -25,7 +25,6 @@ import static net.serenitybdd.core.Serenity.sessionVariableCalled;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.JavascriptExecutor;
@@ -394,6 +393,22 @@ public class ManageSpaceSteps {
     if (!manageSpacesPage.isSpaceMenuDisplayed()) {
       manageSpacesPage.clickSpaceActionToJoin();
     }
+  }
+
+  public void openSpaceInvitationDrawer() {
+    manageSpacesPage.openSpaceInvitationDrawer();    
+  }
+
+  public void inviteEmailAsSpaceMember(String email) {
+    manageSpacesPage.inviteEmailAsSpaceMember(email);    
+  }
+
+  public void emailIsListedInInvitationList(String email, String status) {
+    manageSpacesPage.emailIsListedInInvitationList(email, status);    
+  }
+
+  public void emailIsNotListedInInvitationList(String email) {
+    manageSpacesPage.emailIsNotListedInInvitationList(email);
   }
 
   public String moveApplicationAfter(int appPosition) {

--- a/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
@@ -131,9 +131,14 @@ public class GenericStepDefinitions {
                                                      .isTrue();
   }
 
-  @When("success message is displayed")
+  @When("Success message is displayed")
   public void checkSuccessMessage() {
     genericSteps.checkSuccessMessageDisplayed();
+  }
+
+  @When("Information message is displayed")
+  public void checkInformationMessageDisplayed() {
+    genericSteps.checkInformationMessageDisplayed();
   }
 
   @When("^I confirm$")

--- a/src/test/java/io/meeds/qa/ui/steps/definition/LoginStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/LoginStepDefinitions.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
 import io.meeds.qa.ui.steps.LoginSteps;
 import net.thucydides.core.annotations.Steps;
 
@@ -53,6 +55,16 @@ public class LoginStepDefinitions {
   @Given("I check login page display")
   public void checkLoginPageDisplay() {
     loginSteps.checkLoginPageDisplay();
+  }
+
+  @Then("Register link is displayed")
+  public void checkRegisterLinkIsDisplayed() {
+    loginSteps.checkRegisterLinkIsDisplayed();
+  }
+
+  @Then("Register link is not displayed")
+  public void checkRegisterLinkIsNotDisplayed() {
+    loginSteps.checkRegisterLinkIsNotDisplayed();
   }
 
 }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/MainSettingsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/MainSettingsStepDefinition.java
@@ -1,0 +1,148 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package io.meeds.qa.ui.steps.definition;
+
+import static io.meeds.qa.ui.steps.definition.ManageSpaceStepDefinitions.RANDOM_SPACE_NAME;
+import static net.serenitybdd.core.Serenity.sessionVariableCalled;
+
+import io.meeds.qa.ui.steps.HomeSteps;
+import io.meeds.qa.ui.steps.MainSettingsSteps;
+
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import net.thucydides.core.annotations.Steps;
+
+public class MainSettingsStepDefinition {
+
+  @Steps
+  private MainSettingsSteps mainSettingsSteps;
+
+  @Steps
+  private HomeSteps         homeSteps;
+
+  @When("I go to main settings page")
+  public void goToMainSettingsPage() {
+    homeSteps.goToMainSettings();
+  }
+
+  @When("I open access customizations settings")
+  public void goToAccessCustomization() {
+    mainSettingsSteps.goToAccessCustomization();
+  }
+
+  @When("I open branding customizations settings")
+  public void goToBrandingCustomization() {
+    mainSettingsSteps.goToBrandingCustomization();
+  }
+
+  @When("I open login customizations settings")
+  public void goToLoginCustomization() {
+    mainSettingsSteps.goToLoginCustomization();
+  }
+
+  @When("I go back to Main Settings page")
+  public void goBackToMainSettings() {
+    mainSettingsSteps.goBackToMainSettings();
+  }
+
+  @Then("Access customization settings is displayed")
+  public void checkAccessCustomization() {
+    mainSettingsSteps.checkAccessCustomization();
+  }
+
+  @Then("Branding customization settings is displayed")
+  public void checkBrandingCustomization() {
+    mainSettingsSteps.checkBrandingCustomization();
+  }
+
+  @Then("Login customization settings is displayed")
+  public void checkLoginCustomization() {
+    mainSettingsSteps.checkLoginCustomization();
+  }
+
+  @When("^I add login page title '(.*)'$")
+  public void setLoginTitle(String title) {
+    mainSettingsSteps.setLoginTitle(title);
+  }
+
+  @When("^I add login page sub title '(.*)'$")
+  public void setLoginSubTitle(String title) {
+    mainSettingsSteps.setLoginSubTitle(title);
+  }
+
+  @When("I select random space as default for registered users")
+  public void selectAccessDefaultSpace() {
+    String randomSpaceName = sessionVariableCalled(RANDOM_SPACE_NAME);
+    mainSettingsSteps.selectAccessDefaultSpace(randomSpaceName);
+  }
+
+  @Then("^'(.*)' default spaces are selected for registered users$")
+  public void checkAccessDefaultSpacesCount(int count) {
+    mainSettingsSteps.checkAccessDefaultSpacesCount(count);
+  }
+
+  @When("I apply main settings customizations")
+  public void applyCustomization() {
+    mainSettingsSteps.applyCustomization();
+  }
+
+  @When("I select 'Open' access type")
+  public void selectOpenAccessCustomization() {
+    mainSettingsSteps.selectOpenAccessCustomization();
+  }
+
+  @When("I select 'Restricted' access type")
+  public void selectRestrictedAccessCustomization() {
+    mainSettingsSteps.selectRestrictedAccessCustomization();
+  }
+
+  @When("I switch 'Restricted' access type to enable external users registration")
+  @And("I switch 'Restricted' access type to disabled external users registration")
+  public void switchRestrictedExternalUsers() {
+    mainSettingsSteps.switchRestrictedExternalUsers();
+  }
+
+  @When("I cancel main settings customizations")
+  public void cancelCustomization() {
+    mainSettingsSteps.cancelCustomization();
+  }
+
+  @Then("The apply button is disabled in Main settings customization")
+  public void checkApplyButtonIsDisabled() {
+    mainSettingsSteps.checkApplyButtonIsDisabled();
+  }
+
+  @Then("The apply button is enabled in Main settings customization")
+  public void checkApplyButtonIsEnabled() {
+    mainSettingsSteps.checkApplyButtonIsEnabled();
+  }
+
+  @Then("The 'Restricted' external user switch button is disabled")
+  public void checkRestrictedExternalUserSwitchButtonIsDisabled() {
+    mainSettingsSteps.checkRestrictedExternalUserSwitchButtonIsDisabled();
+  }
+
+  @Then("The 'Open' external user switch button is disabled")
+  public void checkOpenExternalUserSwitchButtonIsDisabled() {
+    mainSettingsSteps.checkOpenExternalUserSwitchButtonIsDisabled();
+  }
+
+}

--- a/src/test/java/io/meeds/qa/ui/steps/definition/ManageSpaceStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/ManageSpaceStepDefinitions.java
@@ -36,7 +36,8 @@ import net.serenitybdd.core.Serenity;
 import net.thucydides.core.annotations.Steps;
 
 public class ManageSpaceStepDefinitions {
-  private static final String RANDOM_SPACE_NAME = "randomSpaceName";
+
+  public static final String RANDOM_SPACE_NAME = "randomSpaceName";
 
   @Steps
   private HomeSteps        homeSteps;
@@ -79,6 +80,26 @@ public class ManageSpaceStepDefinitions {
     homeSteps.goToManageSpacesPage();
     manageSpaceSteps.addSpaceWithInviteUser(randomSpaceName, userFirstName);
     setSessionVariable(RANDOM_SPACE_NAME).to(randomSpaceName);
+  }
+
+  @Given("I open space invitation drawer")
+  public void openSpaceInvitationDrawer() {
+    manageSpaceSteps.openSpaceInvitationDrawer();
+  }
+  
+  @Given("^I enter email '(.*)' to invite in random space$")
+  public void inviteEmailAsSpaceMember(String email) {
+    manageSpaceSteps.inviteEmailAsSpaceMember(email);
+  }
+
+  @Then("^The email '(.*)' is set to '(.*)' in invitations list$")
+  public void emailIsListedInInvitationList(String email, String status) {
+    manageSpaceSteps.emailIsListedInInvitationList(email, status);
+  }
+
+  @Then("^The email '(.*)' is not displayed in invitations list$")
+  public void emailIsNotListedInInvitationList(String email) {
+    manageSpaceSteps.emailIsNotListedInInvitationList(email);
   }
 
   @Given("^I create a (.*) random space$")
@@ -370,7 +391,7 @@ public class ManageSpaceStepDefinitions {
     TestInitHook.spaceWithPrefixDeleted("secondRandomSpaceName");
   }
 
-  @Given("^I go to members tab$")
+  @Given("I go to members tab")
   public void goToMembersTab() {
     manageSpaceSteps.goToMembersTab();
   }

--- a/src/test/resources/features/Administration/MainSettings.feature
+++ b/src/test/resources/features/Administration/MainSettings.feature
@@ -42,7 +42,7 @@ Feature: Main settings page features
 
   Scenario: Main settings - Access modification
     Given I am authenticated as 'admin' random user
-    And I create the random space if not existing
+    And I inject the random space
     And I go to main settings page
 
     When I open access customizations settings

--- a/src/test/resources/features/Administration/MainSettings.feature
+++ b/src/test/resources/features/Administration/MainSettings.feature
@@ -1,0 +1,136 @@
+@administration
+@mainSettings
+Feature: Main settings page features
+
+  Scenario: Main settings elements are displayed
+    Given I am authenticated as 'admin' random user
+    And I go to main settings page
+
+    When I open access customizations settings
+    Then Access customization settings is displayed
+    And The apply button is disabled in Main settings customization
+
+    When I refresh the page
+    Then Access customization settings is displayed
+
+    When I go back to Main Settings page
+    And I refresh the page
+
+    When I open branding customizations settings
+    Then Branding customization settings is displayed
+    And The apply button is disabled in Main settings customization
+
+    When I refresh the page
+    Then Branding customization settings is displayed
+    And The apply button is disabled in Main settings customization
+
+    When I go back to Main Settings page
+    And I refresh the page
+
+    When I open login customizations settings
+    Then Login customization settings is displayed
+    And The apply button is disabled in Main settings customization
+
+    When I refresh the page
+    Then Login customization settings is displayed
+
+    When I add login page title 'Test Login Title'
+    And The apply button is enabled in Main settings customization
+
+    When I add login page sub title 'Test Login Sub Title'
+    And The apply button is enabled in Main settings customization
+
+  Scenario: Main settings - Access modification
+    Given I am authenticated as 'admin' random user
+    And I create the random space if not existing
+    And I go to main settings page
+
+    When I open access customizations settings
+    Then Access customization settings is displayed
+
+    When I select 'Open' access type
+    And I select 'Restricted' access type
+    Then Information message is displayed
+
+    When I close the notification
+    Then The 'Open' external user switch button is disabled
+
+    When I select 'Open' access type
+    Then Information message is displayed
+
+    When I close the notification
+    Then The 'Restricted' external user switch button is disabled
+
+    When I select random space as default for registered users
+    Then '1' default spaces are selected for registered users
+
+  Scenario: Main settings - Open Access Type
+    Given I am authenticated as 'admin' random user
+    And I create the random space if not existing
+    And I go to main settings page
+
+    When I open access customizations settings
+    Then Access customization settings is displayed
+
+    When I select 'Open' access type
+    Then The 'Restricted' external user switch button is disabled
+
+    When I apply main settings customizations
+
+    When I go to the random space
+    And I go to members tab
+    And I open space invitation drawer
+    And I enter email 'openregisteruserinvitation@test.com' to invite in random space
+    Then The email 'openregisteruserinvitation@test.com' is set to 'Pending' in invitations list
+
+    When I click on 'Invite' button in drawer
+    And I wait '3' seconds
+    And I open space invitation drawer
+    Then The email 'openregisteruserinvitation@test.com' is set to 'Invitation Sent' in invitations list
+
+    When I logout
+    Then Register link is displayed
+
+  Scenario: Main settings - Restricted Access Type
+    Given I am authenticated as 'admin' random user
+    And I create the random space if not existing
+    And I go to main settings page
+
+    When I open access customizations settings
+    Then Access customization settings is displayed
+
+    When I select 'Restricted' access type
+    Then The 'Open' external user switch button is disabled
+
+    When I apply main settings customizations
+
+    When I go to the random space
+    And I go to members tab
+    And I open space invitation drawer
+    And I enter email 'restrictedregisteruserinvitation@test.com' to invite in random space
+    Then The email 'restrictedregisteruserinvitation@test.com' is not displayed in invitations list
+
+    When I logout
+    Then Register link is not displayed
+
+    When I am authenticated as 'admin' random user
+    And I go to main settings page
+    And I open access customizations settings
+    Then Access customization settings is displayed
+
+    When I switch 'Restricted' access type to enable external users registration
+    And I apply main settings customizations
+
+    When I go to the random space
+    And I go to members tab
+    And I open space invitation drawer
+    And I enter email 'restrictedregisteruserinvitation@test.com' to invite in random space
+    Then The email 'restrictedregisteruserinvitation@test.com' is set to 'Pending' in invitations list
+
+    When I click on 'Invite' button in drawer
+    And I wait '3' seconds
+    And I open space invitation drawer
+    Then The email 'restrictedregisteruserinvitation@test.com' is set to 'Invitation Sent' in invitations list
+
+    When I logout
+    Then Register link is not displayed

--- a/src/test/resources/features/Gamification/Programs.feature
+++ b/src/test/resources/features/Gamification/Programs.feature
@@ -118,7 +118,7 @@ Feature: Programs
     And I click on 'Add' button in drawer
 
     And I click on 'Activate the program' button
-    Then success message is displayed
+    Then Success message is displayed
     When I close the notification
 
     When I login as 'fourty' random user
@@ -211,7 +211,7 @@ Feature: Programs
 
     And I save the program details
 
-    Then success message is displayed
+    Then Success message is displayed
     When I close the notification
 
     And I click on 'Add action' button
@@ -223,11 +223,11 @@ Feature: Programs
     And I set rule end date
     And I click on 'Add' button in drawer
 
-    Then success message is displayed
+    Then Success message is displayed
     When I close the notification
 
     And I click on 'Activate the program' button
-    Then success message is displayed
+    Then Success message is displayed
     When I close the notification
 
     When I login as 'first' random user
@@ -247,7 +247,7 @@ Feature: Programs
     And I click on 'Next' button in drawer
     And I set user 'first' as program owner
     And I click on 'Save' button in drawer
-    Then success message is displayed
+    Then Success message is displayed
     And I close the notification
 
     When I edit the program from list
@@ -264,7 +264,7 @@ Feature: Programs
     And I click on 'Next' button in drawer
     And I click on 'Save' button in drawer
 
-    Then success message is displayed
+    Then Success message is displayed
     And I close the notification
 
   Scenario: Can't Activate program when no active action


### PR DESCRIPTION
Included Tests:
- When clicking the login page customization, page displays with proper options
- When clicking to branding page, page displays with proper options
- When editing login page characteristics OR branding customization, then appy is enabled and I can confirm it
- When reloading the page, then I actually see the previous page displayed
- When switching from an option to another (open to restricted or the contrary), then an info notification displays
- When open, I cannot select the external user option from restricted
- When restricted, I cannot select the external user option from open
- When setting a default space, then the number of selected space is reminded below the choice in the page
- When the platform is set to be opened, then the login page provides a way to sign up
- When the platform is set to restricted, then the login page only proposes a sign in method authentication
- When setting to true the external users invitation, then space host can invite users from the members app in their space