### PR TITLE
fix: Fix setting rule end date when no enabled date in picker

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/RulePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/RulePage.java
@@ -115,7 +115,9 @@ public class RulePage extends GenericPage {
     selectActionDateChoice("BEFORE");
     actionEndDateElement().click();
     waitForMenuToOpen();
-    randomDateCalenderElement().waitUntilVisible();
+    if (!randomDateCalenderElement().isVisible()) {
+      nextMonthDateCalenderButton().click();
+    }
     randomDateCalenderElement().click();
     waitForMenuToClose();
   }
@@ -251,6 +253,10 @@ public class RulePage extends GenericPage {
 
   private TextBoxElementFacade randomDateCalenderElement() {
     return findTextBoxByXPathOrCSS("//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-table')]//button[not(@disabled)]");
+  }
+
+  private TextBoxElementFacade nextMonthDateCalenderButton() {
+    return findTextBoxByXPathOrCSS("//*[contains(@class,'menuable__content__active')]//*[contains(@class,'v-date-picker-header')]//button[not(@disabled)]//i[contains(@class, 'right')]");
   }
 
   private TextBoxElementFacade ruleDescriptionFieldElement() {


### PR DESCRIPTION
Prior to this change, at each end of a month, when trying to pick an end date to a rule, the current month doesn't have an enabled date to select. This change switch the date picker to next month to be able to select a date for Rule.