### PR TITLE
fix: Fix Activity Test cases to avoid random fails - MEED-2467 - Meeds-io/meeds#1087

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
@@ -17,7 +17,7 @@
  */
 package io.meeds.qa.ui.pages;
 
-import static io.meeds.qa.ui.utils.Utils.refreshPage;
+import static io.meeds.qa.ui.utils.Utils.*;
 import static io.meeds.qa.ui.utils.Utils.retryOnCondition;
 import static io.meeds.qa.ui.utils.Utils.waitForLoading;
 import static org.junit.Assert.assertTrue;
@@ -76,7 +76,10 @@ public class SpaceHomePage extends GenericPage {
         getDriver().switchTo().frame(ckEditorFrameElement());
         activityContentTextBoxElement = activityContentTextBoxElement();
         activityContentTextBoxElement.sendKeys(Keys.CONTROL + "v");
-        activityLinkPreviewElement().waitUntilVisible();
+        int i = MAX_WAIT_RETRIES;
+        while (!activityLinkPreviewElement().isVisible() && i-- > 0) {
+          waitFor(2).seconds();
+        }
       } else if (activity.contains("lien")) {
         activityContentTextBoxElement.click();
         activityContentTextBoxElement.sendKeys(Keys.PAGE_UP);

--- a/src/test/resources/features/Social/ActivityStream.feature
+++ b/src/test/resources/features/Social/ActivityStream.feature
@@ -824,13 +824,14 @@ Feature: Activity Stream
     When In comment 'commenttest109', I hover on Like icon
     Then Tooltip Remove Like on 'commenttest109' is displayed in activity stream
 
-  Scenario: CAP110 - [ActivityStream_US40][02] DisLike my comment/reply from activity stream
+  Scenario: DisLike my comment/reply from activity stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
 
     And I create the first random user if not existing, no wait
-    And I create the second random user if not existing
+    And I create the second random user if not existing, no wait
+    And I inject the random space
 
     And I login as 'first' random user
 
@@ -1344,13 +1345,12 @@ Feature: Activity Stream
     Then Sixth User is not mentioned in the comment
     And I close the opened drawer
 
-  Scenario: Cap146 - [ActivityStream_US40][01] Notifications for comments to my activity
-    Given I am authenticated as 'admin' if random users doesn't exists
-      | first  |
-      | second  |
+  Scenario: Notifications for comments to my activity
+    Given I am authenticated as 'admin' random user
 
     When I create the first random user if not existing, no wait
-    And I create the second random user if not existing
+    And I create the second random user if not existing, no wait
+    And I inject the random space
 
     And I login as 'first' random user
     And I go to the random space

--- a/src/test/resources/features/Social/General.feature
+++ b/src/test/resources/features/Social/General.feature
@@ -32,10 +32,12 @@ Feature: General new composer
     Then the activity 'modifier le lien' is displayed in activity stream
     And The link is displayed with the preview
 
-  Scenario: CAP110 - [US-General-07] update posts - text update with video Link (space case)
+  Scenario: Text update with video Link (space case)
     Given I am authenticated as 'admin' random user
+
+    When I inject the random space
     And I go to the random space
-    When I click on post in space
+    And I click on post in space
     And I enter an activity 'https://www.youtube.com/watch?v=wgpduVyZT50'
     And I wait '5' seconds
     And I insert text 'activity110'

--- a/src/test/resources/features/Tasks/FilterDrawer.feature
+++ b/src/test/resources/features/Tasks/FilterDrawer.feature
@@ -1,7 +1,7 @@
 @task
 Feature: Filter Drawer
 
-  Scenario: CAP110 - [Filter_Drawer_US03]Group by Labels [Group and Sort" tab under project]
+  Scenario: Group and Sort tab under project
     Given I am authenticated as 'admin' random user
 
     When I create a random space


### PR DESCRIPTION
Prior to this change, the admin user was able to add activities to a space where it's not member of. This change ensures to inject the space by the admin user to ensure that it's member of the space to be able to receive notifications.