### PR TITLE
fix: Fix Gamification Automatic Event Name

### DIFF
--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -631,7 +631,7 @@ Feature: Achievements
     And I enter the rule title 'Cancel Space Join'
     And I add rule random description
     And I click on 'Automatic' button in drawer
-    And I add an event 'Spaces : Join space'
+    And I add an event 'Join space'
     And I click on 'Next' button in drawer
     And I click on 'Add' button in drawer
 


### PR DESCRIPTION
This change will enhance an existing use case to delete a prefix while selecting an event name from Gamification Action Drawer.