### PR TITLE
fix: Fix External and internal Link in activities

### DIFF
--- a/src/test/java/io/meeds/qa/ui/steps/definition/SpaceHomeStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/SpaceHomeStepDefinition.java
@@ -213,12 +213,12 @@ public class SpaceHomeStepDefinition {
 
   @Then("^Internal link '(.*)' is displayed in activity stream as a comment$")
   public void checkInternalLinkCommentAS(String comment) {
-    spaceHomeSteps.checkActivityComment(spaceHomePage.getCurrentUrl() + comment);
+    spaceHomeSteps.checkActivityComment(currentUrlNoProtocol() + comment);
   }
 
   @Then("^Internal link '(.*)' is displayed in Comments drawer as a comment$")
   public void checkInternalLinkCommentInDrawer(String comment) {
-    spaceHomeSteps.checkActivityCommentInDrawer(spaceHomePage.getCurrentUrl() + comment);
+    spaceHomeSteps.checkActivityCommentInDrawer(currentUrlNoProtocol() + comment);
   }
 
   @Then("The link is displayed with the preview")
@@ -310,7 +310,7 @@ public class SpaceHomeStepDefinition {
 
   @When("^I click on the internal link '(.*)'$")
   public void clickOnInternalLinkComment(String comment) {
-    spaceHomeSteps.clickOnActivityComment(spaceHomePage.getCurrentUrl() + comment);
+    spaceHomeSteps.clickOnActivityComment(currentUrlNoProtocol() + comment);
   }
 
   @When("^I click on Load more button$")
@@ -685,7 +685,7 @@ public class SpaceHomeStepDefinition {
 
   @Then("^I open the internal link '(.*)' in new tab$")
   public void openInternalLinkInNewTab(String link) {
-    spaceHomeSteps.openLinkInNewTab(spaceHomePage.getCurrentUrl() + link);
+    spaceHomeSteps.openLinkInNewTab(currentUrlNoProtocol() + link);
   }
 
   @Then("^I open link '(.*)' in new tab$")
@@ -837,4 +837,9 @@ public class SpaceHomeStepDefinition {
   public void viewAllRepliesInCommentsDrawer(String comment) {
     spaceHomeSteps.viewAllRepliesInCommentsDrawer(comment);
   }
+
+  private String currentUrlNoProtocol() {
+    return spaceHomePage.getCurrentUrl().replace("https://", "").replace("http://", "").replace("www.", "");
+  }
+
 }

--- a/src/test/resources/features/Social/ActivityStream.feature
+++ b/src/test/resources/features/Social/ActivityStream.feature
@@ -1240,13 +1240,13 @@ Feature: Activity Stream
 
     When I add in activity 'activityTestCAP158-158' a comment 'https://www.meeds.io/'
     And I open in activity 'activityTestCAP158-158' the Comments drawer
-    Then Activity Comment 'https://www.meeds.io/' is displayed in Comments drawer
-    And Activity Comment 'https://www.meeds.io/' is displayed in activity stream
+    Then Activity Comment 'meeds.io' is displayed in Comments drawer
+    And Activity Comment 'meeds.io' is displayed in activity stream
 
-    When I click on comment 'https://www.meeds.io/'
+    When I click on comment 'meeds.io'
     Then Link 'https://www.meeds.io/' is opened in new tab
 
-    When I open link 'https://www.meeds.io/' in new tab
+    When I open link 'meeds.io' in new tab
     Then Link 'https://www.meeds.io/' is opened in new tab
 
   Scenario: CAP97 - [ActivityStream_US38][01] Delete a simple comment from the activity stream


### PR DESCRIPTION
Prior to this change, the protocol (https) was mandatory in activity content test cases. This change will allow to test on target link validity without having to display in content the used http protocol.