### PR TITLE
fix: Fix Space Popover Test Case - MEED-2667 - Meeds-io/meeds#1161

### DIFF
--- a/src/test/resources/features/Social/Favorites.feature
+++ b/src/test/resources/features/Social/Favorites.feature
@@ -162,10 +162,12 @@ Feature: Favorite activities
     When I bookmark the random space as favorite from topbar space popover
     Then Confirmation message is displayed 'Favorite added successfully. Find it easily from the search'
     When I close the notification
+    And I hover on space name from top bar
     Then  I check that the random space is bookmarked as favorite from topbar space popover
     When I unfavorite the random space from topbar space popover
     Then Confirmation message is displayed 'The item has been removed from favorites successfully.'
     When I close the notification
+    And I hover on space name from top bar
     Then I check that the random space is unbookmarked from topbar space popover
 
   Scenario: Left Nav US02.2: Bookmark space from the left menu (desktop)


### PR DESCRIPTION
Prior to this change, the Space Popover Test was failing due to lack of a step in Scenario. In fact the Popover is closed when the user clicks on an action. The existing scenario wasn't reopening the popover but was assuming that it remains open after the user click. This change is considering this step by reopening the popover after each user click to test on buttons status.