### PR TITLE
fix: Fix Task Alert Check Steps - MEED-2709 - Meeds-io/MIPs#99 (#194)

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -111,10 +111,6 @@ public class HomePage extends GenericPage {
     getFavoriteIconActivity(activity).assertVisible();
   }
 
-  public void checkFavSuccessMessage(String message) {
-    getFavoriteSucessMessage(message).assertVisible();
-  }
-
   public void checkNoActivityDisplayed() {
     contextBoxWelcomeActivityElement().assertVisible();
   }
@@ -575,10 +571,6 @@ public class HomePage extends GenericPage {
     return findByXPathOrCSS(String.format(
                                           "//div[contains(@class,'contentBox')]//*[contains(text(),'%s')]//preceding::i[contains(@class,'fa-star')][01]",
                                           activity));
-  }
-
-  private ElementFacade getFavoriteSucessMessage(String message) {
-    return findByXPathOrCSS(String.format("//div[@class='v-alert__content']//*[contains(text(),'%s')]", message));
   }
 
   private ElementFacade getHamburgerNavigationMenu() {

--- a/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
@@ -579,7 +579,7 @@ public class ManageSpacesPage extends GenericPage {
   }
 
   private ElementFacade editIconOfGeneralSpaceSettingsElement() {
-    return findByXPathOrCSS("//i[@class='uiIconEdit uiIconLightBlue pb-2']");
+    return findByXPathOrCSS("//*[contains(text(), 'General')]//ancestor::*[contains(@class, 'v-application')]//*[contains(@class, 'fa-edit')]");
   }
 
   private ElementFacade firstProcessButtonElement() {

--- a/src/main/java/io/meeds/qa/ui/pages/SettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/SettingsPage.java
@@ -20,7 +20,6 @@ package io.meeds.qa.ui.pages;
 import static io.meeds.qa.ui.utils.Utils.refreshPage;
 
 import org.junit.Assert;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 
 import io.meeds.qa.ui.elements.ElementFacade;
@@ -228,19 +227,6 @@ public class SettingsPage extends GenericPage {
 
   }
 
-  public void goToEditGeneralNotifications() {
-    JavascriptExecutor js = (JavascriptExecutor) getDriver();
-
-    try {
-      editGeneralNotificationsElement().waitUntilClickable();
-      editGeneralNotificationsElement().click();
-
-    } catch (Exception ex) {
-      js.executeScript("arguments[0].click();", editGeneralNotificationsElement());
-    }
-
-  }
-
   public void goToManageNotifications() {
     clickOnElement(manageNotificationsElement());
   }
@@ -360,10 +346,6 @@ public class SettingsPage extends GenericPage {
 
   private ElementFacade confirmEditPasswordElement() {
     return findByXPathOrCSS("(//input[@type='password'])[3]/following::*[@class='v-btn__content'][2]");
-  }
-
-  private ElementFacade editGeneralNotificationsElement() {
-    return findByXPathOrCSS("(//*[@class='uiIconEdit uiIconLightBlue pb-2'])[1]");
   }
 
   private ElementFacade editPasswordElement() {

--- a/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
@@ -186,25 +186,13 @@ public class TasksPage extends GenericPage {
     cancelFilterButtonElement().assertVisible();
   }
 
-  public void checkAlertMessageAfterDeleteTask() {
-    findByXPathOrCSS("//*[contains(@class, 'v-alert')]//*[contains(text(),'Task successfully deleted')]").assertVisible();
-  }
-
-  public void checkAlertMessageAfterMarkTaskAsCompleted() {
-    alertMessageAfterMarkTaskAsCompletedElement().assertVisible();
-  }
-
-  public void checkAlertMessageMoveStatusAfter() {
-    alertMessageAfterStatusMovedElement().assertVisible();
-  }
-
   public void checkAttachmentDisplay(String attachmentName) {
     getAttachmentName(attachmentName).assertNotVisible();
   }
 
   public void checkClonedProject(String projectName) {
     getProjectCard(projectName).assertVisible();
-    alertMessageAfterProjectCloneElement().assertVisible();
+    checkSuccessMessageDisplayed();
   }
 
   public void checkClonedTask(String taskName) {
@@ -213,7 +201,7 @@ public class TasksPage extends GenericPage {
 
   public void checkDeletedProject(String projectName) {
     getProjectCard(projectName).assertNotVisible();
-    alertMessageAfterProjectDeletionElement().assertVisible();
+    checkSuccessMessageDisplayed();
   }
 
   public void checkDeletedStatus(String statusColumn) {
@@ -267,11 +255,7 @@ public class TasksPage extends GenericPage {
 
   public void checkProject(String projectName) {
     getProjectCard(projectName).assertVisible();
-    alertMessageAfterProjectCreationElement().assertVisible();
-  }
-
-  public void checkProjectIsCreated() {
-    alertMessageAfterProjectCreationElement().assertVisible();
+    checkSuccessMessageDisplayed();
   }
 
   public void checkProjectNameIsDisplayedInProjectCard(String projectName, String description) {
@@ -281,15 +265,11 @@ public class TasksPage extends GenericPage {
 
   public void checkProjectNotDisplayed(String projectName) {
     getProjectCard(projectName).assertNotVisible();
-    alertMessageAfterProjectCreationElement().assertNotVisible();
+    checkSuccessMessageDisplayed();
   }
 
   public void checkSecondStatusColumn(String columnStatus) {
     assertEquals(secondStatusColumnElement().getText(), columnStatus);
-  }
-
-  public void checkSuccessMessage(String message) {
-    assertTrue(successMessageElement().getText().contains(message));
   }
 
   public void checkTaskPriority(String taskPriority) {
@@ -347,7 +327,7 @@ public class TasksPage extends GenericPage {
   public void checkUpdatedProject(String projectName, String description) {
     getProjectCard(projectName).assertVisible();
     getProjectCardDescription(description).assertVisible();
-    alertMessageAfterProjectUpdateElement().assertVisible();
+    checkSuccessMessageDisplayed();
   }
 
   public void checkViewLinkAttachments() {
@@ -1146,10 +1126,6 @@ public class TasksPage extends GenericPage {
     backDrawerElement().click();
   }
 
-  public void taskAlertIsDisplayed(String message) {
-    getTaskAlert(message).assertVisible();
-  }
-
   public void taskIsMarkedAndDisplayedInCompletedSection(String taskName) {
     Assert.assertEquals(getCompletedTask(taskName).getText(), taskName);
   }
@@ -1279,30 +1255,6 @@ public class TasksPage extends GenericPage {
 
   private ElementFacade addTaskInProjectButtonElement() {
     return findByXPathOrCSS(".tasksViewBoardRowContainer .tasksViewHeader .uiIconSocSimplePlus");
-  }
-
-  private TextBoxElementFacade alertMessageAfterMarkTaskAsCompletedElement() {
-    return findTextBoxByXPathOrCSS("//*[contains(text(),'Task successfully marked as archived')]");
-  }
-
-  private TextBoxElementFacade alertMessageAfterProjectCloneElement() {
-    return findTextBoxByXPathOrCSS("//*[@class='v-alert v-sheet theme--dark success']//*[@class='v-alert__content' and contains(text(),'Project successfully cloned')]");
-  }
-
-  private TextBoxElementFacade alertMessageAfterProjectCreationElement() {
-    return findTextBoxByXPathOrCSS("//*[@class='v-alert v-sheet theme--dark success']//*[@class='v-alert__content' and contains(text(),'Project successfully created')]");
-  }
-
-  private TextBoxElementFacade alertMessageAfterProjectDeletionElement() {
-    return findTextBoxByXPathOrCSS("//*[@class='v-alert v-sheet theme--dark success']//*[@class='v-alert__content' and contains(text(),'Project successfully deleted')]");
-  }
-
-  private TextBoxElementFacade alertMessageAfterProjectUpdateElement() {
-    return findTextBoxByXPathOrCSS("//*[@class='v-alert v-sheet theme--dark success']//*[@class='v-alert__content' and contains(text(),'Project successfully updated')]");
-  }
-
-  private TextBoxElementFacade alertMessageAfterStatusMovedElement() {
-    return findTextBoxByXPathOrCSS("//*[@class='v-alert v-sheet theme--dark success']//*[@class='v-alert__content' and contains(text(),'Status successfully moved')]");
   }
 
   private ElementFacade arrowBackButtonElement() {
@@ -1517,11 +1469,6 @@ public class TasksPage extends GenericPage {
   private ElementFacade getStatusColumn(String statusColumn) {
     return findByXPathOrCSS(String.format("(//*[@class='d-flex tasksViewHeaderLeft']//*[contains(text(),'%s')][1])[1]",
                                           statusColumn));
-  }
-
-  private ElementFacade getTaskAlert(String message) {
-    return findByXPathOrCSS(
-                            String.format("//*[@class='v-alert__content' and contains(text(),'%s')]", message));
   }
 
   private ElementFacade getTaskCommentReplyBtn(String comment) {
@@ -1843,10 +1790,6 @@ public class TasksPage extends GenericPage {
 
   private ElementFacade statusFieldElement() {
     return findByXPathOrCSS("//*[@placeholder='Enter a name for this status']");
-  }
-
-  private TextBoxElementFacade successMessageElement() {
-    return findTextBoxByXPathOrCSS("//*[contains(@class,'drawerParent attachmentsListDrawer')]/following::*[@class='v-alert__content'][1]//span");
   }
 
   private ElementFacade switchToFrameTaskElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
@@ -69,10 +69,6 @@ public class HomeSteps {
     homePage.checkFavIcon(activity);
   }
 
-  public void checkFavSuccessMessage(String message) {
-    homePage.checkFavSuccessMessage(message);
-  }
-
   public void checkNoActivityDisplayed() {
     homePage.checkNoActivityDisplayed();
   }

--- a/src/test/java/io/meeds/qa/ui/steps/SettingsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/SettingsSteps.java
@@ -179,11 +179,6 @@ public class SettingsSteps {
 
   }
 
-  public void goToEditGeneralNotifications() {
-    settingsPage.goToEditGeneralNotifications();
-
-  }
-
   public void goToManageNotifications() {
     settingsPage.goToManageNotifications();
 

--- a/src/test/java/io/meeds/qa/ui/steps/TasksSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/TasksSteps.java
@@ -138,18 +138,6 @@ public class TasksSteps {
     tasksPage.cancelFilterButtonIsDisplayed();
   }
 
-  public void checkAlertMessageAfterDeleteTask() {
-    tasksPage.checkAlertMessageAfterDeleteTask();
-  }
-
-  public void checkAlertMessageAfterMarkTaskAsCompleted() {
-    tasksPage.checkAlertMessageAfterMarkTaskAsCompleted();
-  }
-
-  public void checkAlertMessageMoveStatusAfter() {
-    tasksPage.checkAlertMessageMoveStatusAfter();
-  }
-
   public void checkAttachmentDisplay(String attachmentName) {
     tasksPage.checkAttachmentDisplay(attachmentName);
   }
@@ -221,10 +209,6 @@ public class TasksSteps {
     tasksPage.checkMoveStatusBeforeIconIsNotDisplayed();
   }
 
-  public void checkProjectIsCreated() {
-    tasksPage.checkProjectIsCreated();
-  }
-
   public void checkProjectIsDisplayed(String projectName) {
     tasksPage.checkProject(projectName);
   }
@@ -239,10 +223,6 @@ public class TasksSteps {
 
   public void checkSecondStatusColumn(String columnStatus) {
     tasksPage.checkSecondStatusColumn(columnStatus);
-  }
-
-  public void checkSuccessMessage(String message) {
-    tasksPage.checkSuccessMessage(message);
   }
 
   public void checkTaskPriority(String taskPriority) {
@@ -816,10 +796,6 @@ public class TasksSteps {
 
   public void switchToTASKSTab() {
     tasksPage.switchToTASKSTab();
-  }
-
-  public void taskAlertIsDisplayed(String message) {
-    tasksPage.taskAlertIsDisplayed(message);
   }
 
   public void taskIsDisplayedInProjectDetails(String taskName) {

--- a/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
@@ -150,11 +150,6 @@ public class HomeStepDefinition {
     homeSteps.checkFavIcon(activity);
   }
 
-  @Then("^The favorite success message '(.*)' should be displayed$")
-  public void checkFavSuccessMessage(String message) {
-    homeSteps.checkFavSuccessMessage(message);
-  }
-
   @Given("No activity is displayed in stream$")
   public void checkNoActivityDisplayed() {
     homeSteps.checkNoActivityDisplayed();

--- a/src/test/java/io/meeds/qa/ui/steps/definition/SettingsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/SettingsStepDefinition.java
@@ -207,11 +207,6 @@ public class SettingsStepDefinition {
     settingsSteps.generalNotificationsSendingMailTypeIsWeekly();
   }
 
-  @When("^I click on Edit General Notifications$")
-  public void goToEditGeneralNotifications() {
-    settingsSteps.goToEditGeneralNotifications();
-  }
-
   @When("^I go to Manage Notifications$")
   public void goToManageNotifications() {
     settingsSteps.goToManageNotifications();

--- a/src/test/java/io/meeds/qa/ui/steps/definition/TasksStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/TasksStepDefinition.java
@@ -242,21 +242,6 @@ public class TasksStepDefinition {
     tasksSteps.cancelFilterButtonIsDisplayed();
   }
 
-  @And("^An alert message Task successfully deleted is displayed$")
-  public void checkAlertMessageAfterDeleteTask() {
-    tasksSteps.checkAlertMessageAfterDeleteTask();
-  }
-
-  @Then("An alert message Task successfully marked as archived is displayed")
-  public void checkAlertMessageAfterMarkTaskAsCompleted() {
-    tasksSteps.checkAlertMessageAfterMarkTaskAsCompleted();
-  }
-
-  @Then("^An alert message Status column is moved successfully is displayed$")
-  public void checkAlertMessageMoveStatusAfter() {
-    tasksSteps.checkAlertMessageMoveStatusAfter();
-  }
-
   @Then("^The random created project with description '(.*)' is displayed in Project Card$")
   public void checkCreatedTasksProjectNameIsDisplayedInProjectCard(String projectDescription) {
     String randomSpaceName = Serenity.sessionVariableCalled("randomSpaceName");
@@ -328,11 +313,6 @@ public class TasksStepDefinition {
     tasksSteps.checkClonedProject(randomSpaceName);
   }
 
-  @Then("the project is created successfully and displayed on Tasks Space tab")
-  public void checkProjectIsCreated() {
-    tasksSteps.checkProjectIsCreated();
-  }
-
   @Then("the project is created successfully and displayed on Projects tab")
   public void checkProjectIsDisplayed() {
     String projectName = Serenity.sessionVariableCalled("projectName");
@@ -360,11 +340,6 @@ public class TasksStepDefinition {
   @Then("^Status column '(.*)' is displayed in the second position$")
   public void checkSecondStatusColumn(String columnStatus) {
     tasksSteps.checkSecondStatusColumn(columnStatus);
-  }
-
-  @Then("^The success message '(.*)' should be displayed$")
-  public void checkSuccessMessage(String message) {
-    tasksSteps.checkSuccessMessage(message);
   }
 
   @Then("^Task status '(.*)' is modified successfully$")
@@ -1194,11 +1169,6 @@ public class TasksStepDefinition {
   @And("^I switch to TASKS tab$")
   public void switchToTASKSTab() {
     tasksSteps.switchToTASKSTab();
-  }
-
-  @When("^Alert '(.*)' is displayed$")
-  public void taskAlertIsDisplayed(String message) {
-    tasksSteps.taskAlertIsDisplayed(message);
   }
 
   @When("^Task name '(.*)' is displayed in project details$")

--- a/src/test/resources/features/Social/Favorites.feature
+++ b/src/test/resources/features/Social/Favorites.feature
@@ -13,7 +13,7 @@ Feature: Favorite activities
     When I go to Stream page
     Then The favorite star should be displayed in the published activity 'favorite activity'
     When I favorite the activity posted in the space
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
 
   Scenario: [Favs_US04] Remove the Bookmark for an activity
     Given I am authenticated as 'admin' if random users doesn't exists
@@ -26,10 +26,10 @@ Feature: Favorite activities
     And I publish the activity
     Then The favorite star should be displayed in the published activity 'bookmark activity'
     When I favorite the activity posted in the space
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When I go to Stream page
     And I unbookmark the favorite activity posted in the space
-    Then The favorite success message 'The item has been removed from favorites successfully.' should be displayed
+    Then Success message is displayed
 
   Scenario: [Favs_US05][01] Search by favorites (Filter by favorite button)
     Given I am authenticated as 'admin' if random users doesn't exists
@@ -43,9 +43,9 @@ Feature: Favorite activities
     And the activity 'act_Fav_US05_01_1' is displayed in activity stream
     And the activity 'act_Fav_US05_01_2' is displayed in activity stream
     When I bookmark the activity 'act_Fav_US05_01_1'
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When I bookmark the activity 'act_Fav_US05_01_2'
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When I go to Stream page
     And I access to the unified search page
     When I click on the favorite button
@@ -69,9 +69,9 @@ Feature: Favorite activities
     And the activity 'activityFavs_US051' is displayed in activity stream
     And the activity 'activityFavs_US052' is displayed in activity stream
     When I bookmark the activity 'activityFavs_US051'
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When I bookmark the activity 'activityFavs_US052'
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When I go to Stream page
     And I start the search for 'activityFavs_US05'
     Then The activity is displayed in the search 'activityFavs_US050'
@@ -120,7 +120,7 @@ Feature: Favorite activities
     And the activity 'activityFavs_US06_02_1' is displayed in activity stream
     And the activity 'activityFavs_US06_02_2' is displayed in activity stream
     When I bookmark the activity 'activityFavs_US06_02_2'
-    Then The favorite success message 'Favorite added successfully. Find it easily from the search' should be displayed
+    Then Success message is displayed
     When  I start the search for 'activityFavs_US06_02_'
     Then The activity is displayed in the search 'activityFavs_US06_02_1'
     And The activity is displayed in the search 'activityFavs_US06_02_2'

--- a/src/test/resources/features/Tasks/FilterDrawer.feature
+++ b/src/test/resources/features/Tasks/FilterDrawer.feature
@@ -86,7 +86,7 @@ Feature: Filter Drawer
     And Tasks number '3' is displayed in the column To Do
 
     When I mark the task 'task111-1' as completed in project details
-    Then An alert message Task successfully marked as archived is displayed
+    Then Success message is displayed
     And Task name 'task111-1' is not displayed in project details
 
     When I refresh the page

--- a/src/test/resources/features/Tasks/ManageStatusColumn.feature
+++ b/src/test/resources/features/Tasks/ManageStatusColumn.feature
@@ -27,7 +27,7 @@ Feature: Project manager deletes, moves after/before a status column
     And I click on three dots icon of the first status column
     And I check that Move Status column before option is not displayed
     And I click on Move Status column after option
-    Then An alert message Status column is moved successfully is displayed
+    Then Success message is displayed
     And Status column 'To Do' is moved to the second position
     And Status column 'In Progress' is moved to the first position
 
@@ -43,6 +43,6 @@ Feature: Project manager deletes, moves after/before a status column
     And I click on three dots icon of the last status column
     And I check that Move Status column after option is not displayed
     And I click on Move Status column before option
-    Then An alert message Status column is moved successfully is displayed
+    Then Success message is displayed
     And Status column 'Done' is moved to the third position
     And Status column 'Waiting On' is moved to the last position

--- a/src/test/resources/features/Tasks/Projects.feature
+++ b/src/test/resources/features/Tasks/Projects.feature
@@ -1,7 +1,7 @@
 @task
 Feature: Tasks - Projects
 
-  Scenario: [User_UI_US18.1] Add project with a description
+  Scenario: Add project with a description
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I create the first random user if not existing
@@ -9,9 +9,9 @@ Feature: Tasks - Projects
     And I go to 'Tasks' application
     When I select projects tab
     And I add a new project with a description
-    Then the project is created successfully and displayed on Projects tab
+    Then Success message is displayed
 
-  Scenario: CAP47 - [Project_manager_US03.2] Clone a project
+  Scenario: Clone a project
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I create the first random user if not existing
@@ -29,7 +29,7 @@ Feature: Tasks - Projects
     And I open the cloned project
     Then task 'Copy of task1414' is cloned successfully
 
-  Scenario: CAP174 -[US_Filterfield_01] Add Clear typed characters icon "Filter by project"
+  Scenario: Add Clear typed characters icon "Filter by project"
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I create the first random user if not existing
@@ -44,7 +44,7 @@ Feature: Tasks - Projects
     And The placeholder Filter by project should be displayed
     And The clear button is disappeared from the Filter by project field
 
-  Scenario: CAP17 - [Project_Card_US01] check the display of users avatars with managing permissions
+  Scenario: check the display of users avatars with managing permissions
     Given I am authenticated as 'admin' random user
     And I create the first random user if not existing, no wait
     And I create the second random user if not existing
@@ -59,7 +59,7 @@ Feature: Tasks - Projects
     And Avatar of the first created user is displayed in Project Card
     And Avatar of the second created user is not displayed in Project Card
 
-  Scenario: CAP19 - [User_UI_US09] Project's Tasks "BOARD" view
+  Scenario: Project's Tasks "BOARD" view
     Given I am authenticated as 'admin' random user
 
     And I go to 'Tasks' application
@@ -74,7 +74,7 @@ Feature: Tasks - Projects
     And Status column 'Waiting On' is displayed in the third position
     And Status column 'Done' is displayed in the last position
 
-  Scenario: CAP36 [User_UI_US18.1] Check  message when  Project title is empty
+  Scenario: Check  message when  Project title is empty
     Given I am authenticated as 'admin' random user
 
     And I go to 'Tasks' application
@@ -83,7 +83,7 @@ Feature: Tasks - Projects
     And I click on save project button
     Then Message Project Title is mandatory is displayed
 
-  Scenario: CAP290 - Project participant cannot open the edit status mode
+  Scenario: Project participant cannot open the edit status mode
     Given I am authenticated as 'admin' random user
     And I create the first random user if not existing
 
@@ -114,7 +114,7 @@ Feature: Tasks - Projects
     When I click on Status name 'To Do'
     Then Status name 'To Do' Edit mode is not opened successfully
 
-  Scenario: CAP216 - Task card should be well displayed when task title is long
+  Scenario: Task card should be well displayed when task title is long
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I create the first random user if not existing
@@ -134,7 +134,7 @@ Feature: Tasks - Projects
     Then Task tooltip is displayed 'testlongtasknametestlongtasknametestlongtasknametestlongtasknametestlongtasknametestlongtaskname'
 
   @smoke
-  Scenario: CAP16 - [Project_Card_US01]: check the display "project's creator avatar"
+  Scenario: check the display "project's creator avatar"
     Given I am authenticated as 'admin' random user
     And I create the first random user if not existing
     And I go to 'Tasks' application
@@ -146,7 +146,7 @@ Feature: Tasks - Projects
     Then User avatar 'admin' is displayed in Project Card
     And Avatar of the first created user is not displayed in Project Card
 
-  Scenario: CAP43-[Project_manager_US02]:Delete a Project
+  Scenario: Delete a Project
     Given I am authenticated as 'admin' random user
     And I create a random space
     And I open the app center menu
@@ -159,7 +159,7 @@ Feature: Tasks - Projects
     And I click on delete to confirm project deletion
     Then the project is deleted successfully from Projects tab
 
-  Scenario: CAP44 - [Project_manager_US02]: Cancel Deletion of Project
+  Scenario: Cancel Deletion of Project
     Given I am authenticated as 'admin' random user
     And I create a random space
     And I open the app center menu

--- a/src/test/resources/features/Tasks/Tasks.feature
+++ b/src/test/resources/features/Tasks/Tasks.feature
@@ -15,7 +15,7 @@ Feature: Tasks
     And I create the following task in selected project
       | taskName | tasktest |
     And I mark the task as completed from the task card
-    Then An alert message Task successfully marked as archived is displayed
+    Then Success message is displayed
     And Task name 'tasktest' is not displayed in project details
     And Tasks number '0' is displayed in the column To Do
 
@@ -70,7 +70,7 @@ Feature: Tasks
     And I create the following task in selected project
       | taskName | task11 |
     And I mark the task as completed from the task card
-    Then An alert message Task successfully marked as archived is displayed
+    Then Success message is displayed
     And Task name 'task11' is not displayed in project details
     And Tasks number '0' is displayed in the column To Do
 
@@ -95,7 +95,7 @@ Feature: Tasks
     Then Delete task option is displayed
     When I click on task delete option
     And I confirm deletion Task message
-    Then An alert message Task successfully deleted is displayed
+    Then Success message is displayed
     When I close the opened drawer
     Then Task name 'taskessai' is not displayed in project details
 
@@ -137,7 +137,7 @@ Feature: Tasks
     And I create a random space
     And I go to Tasks in space tab
     And I create the project 'new project test'
-    Then the project is created successfully and displayed on Tasks Space tab
+    Then Success message is displayed
 
     And I go to 'Tasks' application
     And Project 'new project test' is displayed in Tasks App Center
@@ -150,7 +150,7 @@ Feature: Tasks
     When I refresh the page
     And I go to Tasks in space tab
     And I create the project 'second project test'
-    Then the project is created successfully and displayed on Tasks Space tab
+    Then Success message is displayed
     And Project 'second project test' is displayed in Tasks space
 
     And I go to 'Tasks' application
@@ -241,7 +241,7 @@ Feature: Tasks
     And I open the task 'task E'
     And I mark the task as completed in task drawer without closing the drawer
     Then The task is marked as completed in task drawer
-    Then An alert message Task successfully marked as archived is displayed
+    Then Success message is displayed
 
     When I close the opened drawer
     And Task name 'taskE' is not displayed in project details


### PR DESCRIPTION
Prior to this change, the Task alert messages wasn't reusing the Snack bar component. After MIP#99, the Tasks alerts were changed to use the reusable alert messages component centralized in a page. This change will delete specific Task alert messages check to reuse a simplified check (without being dependant from Crowdin Translation changes).