### PR TITLE
fix: Fix Programs Overview Listing - MEED-2871 - Meeds-io/MIPs#100

### DIFF
--- a/src/test/java/io/meeds/qa/ui/steps/ManageSpaceSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/ManageSpaceSteps.java
@@ -122,6 +122,17 @@ public class ManageSpaceSteps {
     manageSpacesPage.saveSpace();
   }
 
+  public void addSpaceWithRegistrationAndInviteUser(String spaceName, String registration, String user) {
+    manageSpacesPage.openSpaceFormDrawer();
+    manageSpacesPage.setSpaceName(spaceName);
+    manageSpacesPage.setSpaceDescription(spaceName);
+    manageSpacesPage.clickFirstProcessButton();
+    manageSpacesPage.checkSpaceRegistration(registration);
+    manageSpacesPage.clickSecondProcessButton();
+    manageSpacesPage.inviteUserToSpace(user);
+    manageSpacesPage.saveSpace();
+  }
+
   public void addSpaceWithRegistration(String spaceName, String registration) {
     manageSpacesPage.openSpaceFormDrawer();
     manageSpacesPage.setSpaceName(spaceName);

--- a/src/test/java/io/meeds/qa/ui/steps/definition/ManageSpaceStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/ManageSpaceStepDefinitions.java
@@ -82,6 +82,23 @@ public class ManageSpaceStepDefinitions {
     setSessionVariable(RANDOM_SPACE_NAME).to(randomSpaceName);
   }
 
+  @Given("^I create the '(.*)' random space with the '(.*)' random user as member and registration '(.*)'$")
+  public void addARandomSpaceWithRegistrationAndRandomUserInvited(String spacePrefix, String userPrefix, String registration) {
+    String randomSpaceName = RANDOM_SPACE_NAME + getRandomNumber();
+    String userFirstName = Serenity.sessionVariableCalled(userPrefix + "UserFirstName");
+    homeSteps.goToManageSpacesPage();
+    manageSpaceSteps.addSpaceWithRegistrationAndInviteUser(randomSpaceName, registration, userFirstName);
+    setSessionVariable(spacePrefix + "RandomSpaceName").to(randomSpaceName);
+  }
+
+  @Given("^I create the '(.*)' random space with registration '(.*)'$")
+  public void addARandomSpaceWithRegistration(String spacePrefix, String registration) {
+    String randomSpaceName = RANDOM_SPACE_NAME + getRandomNumber();
+    homeSteps.goToManageSpacesPage();
+    manageSpaceSteps.addSpaceWithRegistration(randomSpaceName, registration);
+    TestInitHook.spaceWithPrefixCreated(spacePrefix + "RandomSpaceName", randomSpaceName, Serenity.getDriver().getCurrentUrl());
+  }
+
   @Given("I open space invitation drawer")
   public void openSpaceInvitationDrawer() {
     manageSpaceSteps.openSpaceInvitationDrawer();

--- a/src/test/resources/features/Gamification/ProgramsOverview.feature
+++ b/src/test/resources/features/Gamification/ProgramsOverview.feature
@@ -7,9 +7,9 @@ Feature: Programs should be displayed in Top Programs in sorted way
     Given I am authenticated as 'admin' random user
 
     When I create the thirtyone random user
-    And I create the thirtyone random space with the thirtyone random user as member
-    And I create the thirtytwo random space with the thirtyone random user as member
-    And I create the thirtythree random space
+    And I create the 'thirtyone' random space with the 'thirtyone' random user as member and registration 'Validation'
+    And I create the 'thirtytwo' random space with the 'thirtyone' random user as member and registration 'Validation'
+    And I create the 'thirtythree' random space with registration 'Validation'
 
     When I go to 'Contributions' application
     And I create the 'thirtytwo' random program with


### PR DESCRIPTION
Prior to this change, the Test case 'Programs Overview Widget sorted by modified date' has failed on CI. This is due to changes made on MIP#100 to let programs with Open Space audience listed even not member. This change will adapt the test case to consider Spaces with Validation registration type.