### PR TITLE
fix: Fix Administration Menu Access - Meeds-io/MIPs#88

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
@@ -100,6 +100,10 @@ public class ApplicationPage extends GenericPage {
   }
 
   public void clickOnTheAppLauncherIcon() {
+    if (getCurrentUrl().contains("/portal/administration")) {
+      getDriver().navigate().to(getCurrentUrl().split("/portal")[0]);
+      verifyPageLoaded();
+    }
     waitForLoading();
     closeAllDrawers();
     retryOnCondition(() -> {
@@ -111,10 +115,6 @@ public class ApplicationPage extends GenericPage {
   }
 
   public void goToApplication(String application) {
-    if (getCurrentUrl().contains("/portal/administration")) {
-      getDriver().navigate().to(getCurrentUrl().split("/portal")[0]);
-      verifyPageLoaded();
-    }
     clickOnTheAppLauncherIcon();
     getApplication(application).click();
     waitForLoading();

--- a/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ApplicationPage.java
@@ -111,6 +111,10 @@ public class ApplicationPage extends GenericPage {
   }
 
   public void goToApplication(String application) {
+    if (getCurrentUrl().contains("/portal/administration")) {
+      getDriver().navigate().to(getCurrentUrl().split("/portal")[0]);
+      verifyPageLoaded();
+    }
     clickOnTheAppLauncherIcon();
     getApplication(application).click();
     waitForLoading();

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -52,29 +52,8 @@ public class HomePage extends GenericPage {
   }
 
   public void accessToAdministrationMenu() {
-    retryOnCondition(() -> {
-      clickOnHamburgerMenu();
-      administrationMenuElement().waitUntilVisible();
-      ElementFacade administrationIconElement = administrationIconElement();
-      if (administrationIconElement.isVisible()) {
-        waitFor(300).milliseconds(); // Wait for animations to finish
-        Actions action = new Actions(getDriver());
-        action.moveToElement(administrationIconElement).build().perform();
-        ElementFacade arrowAdminstrationMenuElement = arrowAdminstrationMenuElement();
-        if (arrowAdminstrationMenuElement.isVisible()) {
-          arrowAdminstrationMenuElement.click();
-        } else {
-          throw new ElementShouldBeVisibleException(String.format("Administration menu arrow should be visible %s",
-                                                                  arrowAdminstrationMenuElement),
-                                                    null);
-        }
-      } else {
-        throw new ElementShouldBeVisibleException(String.format("Administration menu cog icon should be visible %s",
-                                                                administrationIconElement),
-                                                  null);
-      }
-      findByXPathOrCSS("#AdministrationHamburgerNavigation .subItemTitle").checkVisible();
-    }, Utils::refreshPage);
+    administrationMenuElement().waitUntilVisible();
+    getDriver().navigate().to(administrationMenuElement().getAttribute("href"));
   }
 
   public void accessToRecentSpaces() {
@@ -200,23 +179,23 @@ public class HomePage extends GenericPage {
   }
 
   public void goToAddGroups() {
-    goToAdministrationPage("/groupsManagement");
+    goToAdministrationPage("organisation/groups");
   }
   
   public void goToAddUser() {
-    goToAdministrationPage("/usersManagement");
+    goToAdministrationPage("organisation/users");
   }
 
   public void goToMainSettings() {
-    goToAdministrationPage("/generalSettings", true);
+    goToAdministrationPage("general/mainsettings", true);
   }
 
   public void goToAppCenterAdminSetupPage() {
-    goToAdministrationPage("/appCenterAdminSetup");
+    goToAdministrationPage("general/applicationsCenter");
   }
 
   public void goToNotificationAdminPage() {
-    goToAdministrationPage("/notification");
+    goToAdministrationPage("general/notification");
   }
 
   public void goToHomePage() {
@@ -372,6 +351,10 @@ public class HomePage extends GenericPage {
   }
 
   public void clickOnHamburgerMenu() {
+    if (getCurrentUrl().contains("/portal/administration")) {
+      getDriver().navigate().to(getCurrentUrl().split("/portal")[0]);
+      verifyPageLoaded();
+    }
     retryOnCondition(() -> {
       closeToastNotification(false);
       closeAllDialogs();
@@ -478,7 +461,7 @@ public class HomePage extends GenericPage {
     if (forceRefresh || !StringUtils.contains(getDriver().getCurrentUrl(), uri)) {
       accessToAdministrationMenu();
       waitFor(50).milliseconds();
-      findByXPathOrCSS(String.format("//*[@id = 'AdministrationHamburgerNavigation']//a[contains(@href, '%s')]", uri)).click();
+      findByXPathOrCSS(String.format("//*[@id = 'siteNavigationTree']//a[contains(@href, '%s')]", uri)).click();
       waitForPageLoading();
     }
   }
@@ -528,20 +511,12 @@ public class HomePage extends GenericPage {
     return findByXPathOrCSS(String.format("//*[contains(@class, 'HamburgerMenuSecondLevelParent')]//p[contains(text(), '%s')]", spaceName));
   }
 
-  private ElementFacade administrationIconElement() {
-    return findByXPathOrCSS("//*[@id='AdministrationHamburgerNavigation']//*[contains(@class,'titleIcon')]");
-  }
-
   private ElementFacade administrationMenuElement() {
-    return findByXPathOrCSS("#AdministrationHamburgerNavigation");
+    return findByXPathOrCSS("//*[@id='platformSettings']/parent::*/a");
   }
 
   private ElementFacade appCenterButtonElement() {
     return findByXPathOrCSS("#appcenterLauncherButton");
-  }
-
-  private ElementFacade arrowAdminstrationMenuElement() {
-    return findByXPathOrCSS("//*[@id='AdministrationHamburgerNavigation']//*[contains(@class,'fa fa-arrow')]");
   }
 
   private ElementFacade checkSpaceFromDrawer(String spaceName) {

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -295,12 +295,6 @@ public class HomePage extends GenericPage {
     waitForPageLoading();
   }
 
-  public void openAppCenterMenu() {
-    waitForPageLoading();
-    clickOnElement(appCenterButtonElement());
-    waitForLoading();
-  }
-
   public void openConnectionRequestDrawer() {
     ElementFacade badgeButton = findByXPathOrCSS("#profile-stats-connectionsCount .v-badge button");
     clickOnElement(badgeButton);
@@ -520,10 +514,6 @@ public class HomePage extends GenericPage {
 
   private ElementFacade administrationMenuElement() {
     return findByXPathOrCSS("//*[@id='platformSettings']/parent::*/a");
-  }
-
-  private ElementFacade appCenterButtonElement() {
-    return findByXPathOrCSS("#appcenterLauncherButton");
   }
 
   private ElementFacade checkSpaceFromDrawer(String spaceName) {

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -52,8 +52,11 @@ public class HomePage extends GenericPage {
   }
 
   public void accessToAdministrationMenu() {
-    administrationMenuElement().waitUntilVisible();
-    getDriver().navigate().to(administrationMenuElement().getAttribute("href"));
+    if (!getCurrentUrl().contains("/portal/administration")) {
+      administrationMenuElement().waitUntilVisible();
+      getDriver().navigate().to(administrationMenuElement().getAttribute("href"));
+      verifyPageLoaded();
+    }
   }
 
   public void accessToRecentSpaces() {
@@ -460,8 +463,7 @@ public class HomePage extends GenericPage {
   private void goToAdministrationPage(String uri, boolean forceRefresh) {
     if (forceRefresh || !StringUtils.contains(getDriver().getCurrentUrl(), uri)) {
       accessToAdministrationMenu();
-      waitFor(50).milliseconds();
-      findByXPathOrCSS(String.format("//*[@id = 'siteNavigationTree']//a[contains(@href, '%s')]", uri)).click();
+      administrationMenuItem(uri).click();
       waitForPageLoading();
     }
   }
@@ -477,6 +479,11 @@ public class HomePage extends GenericPage {
     pageLinkElement(linkSuffix).click();
     waitForPageLoading();
     assertThat(getDriver().getCurrentUrl()).endsWith(linkSuffix);
+  }
+
+  private ElementFacade administrationMenuItem(String uri) {
+    return findByXPathOrCSS(String.format("//*[@id = 'siteNavigationTree']//a[contains(@href, '%s')]",
+                                          uri));
   }
 
   private ElementFacade stickHamburgerMenuElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
@@ -25,7 +25,7 @@ import net.serenitybdd.core.Serenity;
 
 public class HomeSteps {
 
-  private HomePage homePage;
+  private HomePage        homePage;
 
   public void acceptConnectionInvitations(List<String> names, boolean isPrefix) {
     for (String name : names) {
@@ -250,10 +250,6 @@ public class HomeSteps {
 
   public void openAllApplicationPage() {
     homePage.openAllApplicationPage();
-  }
-
-  public void openAppCenterMenu() {
-    homePage.openAppCenterMenu();
   }
 
   public void openNotifications() {

--- a/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
@@ -347,11 +347,6 @@ public class HomeStepDefinition {
     homeSteps.openAllApplicationPage();
   }
 
-  @When("^I open the app center menu$")
-  public void openAppCenterMenu() {
-    homeSteps.openAppCenterMenu();
-  }
-
   @When("^I open Notifications$")
   public void openNotifications() {
     homeSteps.openNotifications();

--- a/src/test/resources/features/AppCenter/AppCenter.feature
+++ b/src/test/resources/features/AppCenter/AppCenter.feature
@@ -15,13 +15,14 @@ Feature: Application center Addon
     And Edit application permissions '/platform/analytics' and '/platform/administrators' are displayed in drawer
     And I refresh the page
 
+  @test
   Scenario: CAP79-[Admin_UI_US07][02]Delete an app
     Given I am authenticated as 'admin' random user
     And I go to Administer application center Page
     When I add a new random application
     And I search for the random created application
     And I delete the created application
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     And I search for the random created application
     Then The random application is not displayed in application list
@@ -119,7 +120,7 @@ Feature: Application center Addon
     And I go to Administer application center Page
     When I add a new random application
     And I login as 'first' random user
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     And I search for the random created application
     Then The random application is displayed in application list
@@ -127,7 +128,7 @@ Feature: Application center Addon
     And I go to Administer application center Page
     And I click on the added application active button
     And I login as 'first' random user
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     And I search for the random created application
     Then The random application is not displayed in application list

--- a/src/test/resources/features/AppCenter/AppCenter.feature
+++ b/src/test/resources/features/AppCenter/AppCenter.feature
@@ -15,7 +15,6 @@ Feature: Application center Addon
     And Edit application permissions '/platform/analytics' and '/platform/administrators' are displayed in drawer
     And I refresh the page
 
-  @test
   Scenario: CAP79-[Admin_UI_US07][02]Delete an app
     Given I am authenticated as 'admin' random user
     And I go to Administer application center Page

--- a/src/test/resources/features/Tasks/Projects.feature
+++ b/src/test/resources/features/Tasks/Projects.feature
@@ -149,7 +149,7 @@ Feature: Tasks - Projects
   Scenario: Delete a Project
     Given I am authenticated as 'admin' random user
     And I create a random space
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     When I go to 'Tasks' application
     And I select projects tab
@@ -162,7 +162,7 @@ Feature: Tasks - Projects
   Scenario: Cancel Deletion of Project
     Given I am authenticated as 'admin' random user
     And I create a random space
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     When I go to 'Tasks' application
     And I select projects tab

--- a/src/test/resources/features/Tasks/Tasks.feature
+++ b/src/test/resources/features/Tasks/Tasks.feature
@@ -457,7 +457,7 @@ Feature: Tasks
 
   Scenario: CAP37 - [User_UI_US18.1] Check message when project title contains less than 3 characters
     Given I am authenticated as 'admin' random user
-    And I open the app center menu
+    And I go To AppCenter Drawer
     And I open all application page
     When I go to 'Tasks' application
     And I select projects tab


### PR DESCRIPTION
Prior to this change, the access to administration menu isn't possible due to changes introduced in Meeds-io/MIPs#88 which moves the administration access to a dedicated site. This change will make adaptations to allow access to administration menu through new menu entry and not from Hamburger Menu anymore.