### PR TITLE
fix: Enhance Space Management permission configuration - MEED-3300

### DIFF
--- a/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
+++ b/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
@@ -271,6 +271,7 @@ public class TestInitHook {
     }
 
     addAdminRandomUser();
+    manageSpaceSteps.configureSpaceCreationPermission();
     loginAsRandomAdmin();
     if (INIT_DATA) {
       injectSpaces();


### PR DESCRIPTION
Prior to this change, the automatic tests relies on default configuration to make sure that simple users can create a space while it can change on production with an existing database. This change will make sure to configure the Space Creation Permissions to allow simple users to create spaces to fit Automatic Tests prerequisite conditions.