### PR TITLE
fix: Fix Email notification Setting - MEED-6512

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/NotificationSettingsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/NotificationSettingsPage.java
@@ -69,12 +69,6 @@ public class NotificationSettingsPage extends GenericPage {
     personalSettingEmailNotificationElement().assertNotVisible();
   }
 
-  public void checkEmailNotificationIsDisplayedForAllTypes() {
-    personalSettingNotificationTypeButton("activity").click();
-    emailNotifDrawerSwitch().assertVisible();
-    closeDrawerIfDisplayed();
-  }
-
   public void disableEmailNotification(String notificationType) {
     personalSettingNotificationTypeButton(notificationType).click();
     waitForDrawerToOpen();

--- a/src/test/java/io/meeds/qa/ui/steps/NotificationSettingsStep.java
+++ b/src/test/java/io/meeds/qa/ui/steps/NotificationSettingsStep.java
@@ -51,10 +51,6 @@ public class NotificationSettingsStep {
     notificationSettingsPage.checkEmailNotificationIsHiddenForAllTypes();
   }
 
-  public void checkEmailNotificationIsDisplayedForAllTypes() {
-    notificationSettingsPage.checkEmailNotificationIsDisplayedForAllTypes();
-  }
-
   public void disableEmailNotification(String notificationType) {
     notificationSettingsPage.disableEmailNotification(notificationType);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/NotificationSettingsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/NotificationSettingsStepDefinition.java
@@ -62,11 +62,6 @@ public class NotificationSettingsStepDefinition {
     notificationSettingsStep.checkEmailNotificationIsHiddenForAllTypes();
   }
 
-  @Then("The email notification settings are displayed in some notification types")
-  public void checkEmailNotificationIsDisplayedForAllTypes() {
-    notificationSettingsStep.checkEmailNotificationIsDisplayedForAllTypes();
-  }
-
   @When("I enable email notification personal setting")
   public void enablePersonalEmailNotification() {
     notificationSettingsStep.enablePersonalEmailNotification();

--- a/src/test/resources/features/Administration/NotificationSettings.feature
+++ b/src/test/resources/features/Administration/NotificationSettings.feature
@@ -15,13 +15,14 @@ Feature: Notification Settings
 
     When I go to notification administration Page
     And I enable email notifications for all users
+    And I enable email notification for 'User is mentioned in a message'
     And I go to Settings page
 
     Then The email notification setting is displayed
 
     When I enable email notification personal setting
     And I go to manage notifications from settings page
-    Then The email notification settings are displayed in some notification types
+    Then The email notification setting for 'Someone @mentions me' is displayed
 
   Scenario: Enable/Disbale email channel for a notification type
     Given I am authenticated as 'admin' random user


### PR DESCRIPTION
Prior to this change, when the instance disn't have email notification settings enabled or didn't have the email notification setting enable for <Activity Notification Types>, then the test fails. This change will ensure to have the test succeeds even if the data of site didn't uses the default configuration which enables all email notifications by default (assuptions are verified in Test case to make sure that Test condition are relevant before making assertions)..