### PR TITLE
fix: Fix Stream And Action Drawer Test Cases - MEED-7078

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/RulePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/RulePage.java
@@ -52,9 +52,6 @@ public class RulePage extends GenericPage {
     if (StringUtils.isNotBlank(description)) {
       setActionDescription(description);
     }
-    if (StringUtils.isNotBlank(points)) {
-      setActionPoints(points);
-    }
 
     if (newRule) {
       if (manual) {
@@ -65,6 +62,10 @@ public class RulePage extends GenericPage {
     }
 
     clickOnNextButton();
+
+    if (StringUtils.isNotBlank(points)) {
+      setActionPoints(points);
+    }
 
     if (changeDates) {
       selectDurationChoice();

--- a/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/SpaceHomePage.java
@@ -420,35 +420,12 @@ public class SpaceHomePage extends GenericPage {
     commentsDrawerSecondPageBtnElement().click();
   }
 
-  public void clickOnCommentThreeDotsButton(String activity, String comment) {
-    if (isMenuDisplayed()) {
-      closeMenu();
-    }
-    retryOnCondition(() -> {
-      getDropDownCommentMenu(activity, comment).click();
-      waitMenuToDisplay();
-    });
-  }
-
-  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    getDropDownCommentMenuFromCommentsDrawer(comment).click();
-  }
-
-  public void clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    getDropDownFirstCommentMenuFromCommentsDrawer(comment).click();
-  }
-
-  public void clickOnCommentThreeDotsInCommentsDrawer(String comment) {
-    ElementFacade commentsDrawerDropDownMenu = getCommentsDrawerDropDownMenu(comment);
-    clickOnElement(commentsDrawerDropDownMenu);
+  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment, boolean reply) {
+    getDropDownCommentMenuFromCommentsDrawer(comment, reply).click();
   }
 
   public void clickOnConfirmButton() {
     getConfirmButton("Confirm").click();
-  }
-
-  public void clickOnDeleteReplyButton(String activity, String comment, String reply) {
-    getDropDownReplyMenu(activity, comment, reply).click();
   }
 
   public void clickOnkudosButtonFromCommentsDrawerToCommentActivity() {
@@ -478,12 +455,6 @@ public class SpaceHomePage extends GenericPage {
 
   public void clickOnLoadMoreActivities() {
     loadMoreActivitiesBtnElement().click();
-  }
-
-  public void clickOnReplyDropDownMenu(String activity, String comment, String reply) {
-    ElementFacade threeDots = getDropDownReplyMenu(activity, comment, reply);
-    threeDots.waitUntilVisible();
-    threeDots.click();
   }
 
   public void clickOnReplyKudos(String reply) {
@@ -879,11 +850,6 @@ public class SpaceHomePage extends GenericPage {
     getDeleteActivityIcon(activity).click();
   }
 
-  public void openDeleteCommentMenu(String activity, String comment) {
-    getDropDownCommentMenu(activity, comment).click();
-    getDeleteCommentLabel(comment).click();
-  }
-
   public void openEditActivityMenu(String activity) {
     openThreeDotsActivityMenu(activity);
     getEditActivityIcon(activity).click();
@@ -904,26 +870,13 @@ public class SpaceHomePage extends GenericPage {
     });
   }
 
-  public void openThreeDotsCommentMenu(String comment) {
-    if (isMenuDisplayed()) {
-      closeMenu();
-    }
-    retryOnCondition(() -> {
-      getDropDownCommentMenu(comment).click();
-      waitMenuToDisplay();
-    });
-  }
-
   public boolean isThreeDotsActivityMenuOpen(String activity) {
     return getDropDownActivityMenu(activity).isVisible();
   }
 
   public void openThreeDotsCommentMenu(String activity, String comment) {
-    getDropDownCommentMenu(activity, comment).click();
-  }
-
-  public boolean isThreeDotsCommentMenuOpen(String activity, String comment) {
-    return getDropDownCommentMenu(activity, comment).isVisible();
+    checkCommentDrawerOpened(activity);
+    clickOnCommentThreeDotsButtonFromCommentsDrawer(comment, false);
   }
 
   public void pinActivityButtonIsDisplayed(String activity) {
@@ -1307,7 +1260,7 @@ public class SpaceHomePage extends GenericPage {
     return findByXPathOrCSS(OPENED_ACTIVITY_COMPOSER_DRAWER_SELECTOR + CKE_WYSIWYG_FRAME_SUFFIX);
   }
 
-  private void clickOnReplyToComment(String comment, String activity) { // NOSONAR
+  private void clickOnReplyToComment(String comment, String activity) {
     checkCommentDrawerOpened(activity);
     getCommentReply(comment).click();
     waitForDrawerToOpen();
@@ -1469,11 +1422,6 @@ public class SpaceHomePage extends GenericPage {
                                           activityComment));
   }
 
-  private ElementFacade getCommentsDrawerDropDownMenu(String comment) {
-    return findByXPathOrCSS(String.format("//*[contains(@class,'drawerHeader')]/following::*[contains(@id,'Extactivity-content-extensions')]//div[contains(text(),'%s')]/preceding::i[contains(@class,'mdi mdi-dots-vertical')][1]/ancestor::button",
-                                          comment));
-  }
-
   private ElementFacade getCommentsDrawerLikeCommentIcon(String activityComment) {
     return findByXPathOrCSS(String.format("(//*[contains(@class,'drawerContent')]//div[contains(text(),'%s')]//following::button[contains(@id,'LikeLinkcomment')])[1]",
                                           activityComment));
@@ -1555,31 +1503,10 @@ public class SpaceHomePage extends GenericPage {
                                           activity));
   }
 
-  private ElementFacade getDropDownCommentMenu(String activity, String comment) {
-    return findByXPathOrCSS(String.format("//*[contains(@class,'activity-detail')]//*[contains(@class, 'postContent')]//*[contains(text(),'%s')]//ancestor::*[contains(@class,'activity-detail')]//*[contains(@class,'activity-comment')]//*[contains(@class,'activity-comment')]//*[contains(text(),'%s')]//ancestor-or-self::*[contains(@class,'activity-comment') and contains(@id, 'ActivityCommment_')][1]//i[contains(@class, 'mdi-dots-vertical')]//ancestor::button",
-                                          activity,
-                                          comment));
-  }
-
-  private ElementFacade getDropDownCommentMenu(String comment) {
-    return findByXPathOrCSS(String.format("//*[contains(@class,'activity-detail')]//*[contains(@class,'activity-comment')]//*[contains(@class,'activity-comment')]//*[contains(text(),'%s')]//ancestor-or-self::*[contains(@class,'activity-comment') and contains(@id, 'ActivityCommment_')][1]//i[contains(@class, 'mdi-dots-vertical')]//ancestor::button",
-                                          comment));
-  }
-
-  private ElementFacade getDropDownFirstCommentMenuFromCommentsDrawer(String comment) {
-    return findByXPathOrCSS(String.format("(//*[@id='activityCommentsDrawer']//*[contains(@class,'d-inline-flex flex-column activity-comment')][1]//*[contains(@class,'v-icon notranslate primary--text')])[1]", // NOSONAR
-                                          comment));
-  }
-
-  private ElementFacade getDropDownCommentMenuFromCommentsDrawer(String comment) {
-    return findByXPathOrCSS(String.format("(//*[@id='activityCommentsDrawer']//*[contains(@class,'d-inline-flex flex-column activity-comment')][4]//*[contains(@class,'v-icon notranslate primary--text')])[1]", // NOSONAR
-                                          comment));
-  }
-
-  private ElementFacade getDropDownReplyMenu(String activity, String comment, String reply) { // NOSONAR
-    return findByXPathOrCSS(String.format("//*[contains(@class,'activity-detail')]//*[contains(@class, 'postContent')]//*[contains(text(),'%s')]//ancestor::*[contains(@class,'activity-detail')]//*[contains(@class,'activity-comment')]//*[contains(@class,'activity-comment')]//*[contains(text(),'%s')]//ancestor-or-self::*[contains(@class,'activity-comment') and contains(@id, 'ActivityCommment_')][1]//i[contains(@class, 'mdi-dots-vertical')]//ancestor::button",
-                                          activity,
-                                          reply));
+  private ElementFacade getDropDownCommentMenuFromCommentsDrawer(String comment, boolean reply) {
+    return findByXPathOrCSS(String.format("(//*[@id='activityCommentsDrawer']//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'activity-comment ')])[%s]//button//*[contains(@class, 'dots') or contains(@class, 'ellipsis')]",
+                                          comment,
+                                          reply ? "2" : "1"));
   }
 
   private ElementFacade getEditActivityIcon(String activity) {

--- a/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
@@ -82,7 +82,7 @@ public class TasksPage extends GenericPage {
   public void addProject(String projectName) {
     addProjectOrTaskElement().click();
     projectTitleElement().setTextValue(projectName);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -112,7 +112,7 @@ public class TasksPage extends GenericPage {
       getDriver().switchTo().defaultContent();
     }
 
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -120,7 +120,7 @@ public class TasksPage extends GenericPage {
     addProjectOrTaskElement().click();
     projectTitleElement().setTextValue(projectName);
     addProjectManagerInput(fullName);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -128,7 +128,7 @@ public class TasksPage extends GenericPage {
     addProjectOrTaskElement().click();
     projectTitleElement().setTextValue(projectName);
     addProjectParticipantInput(participant);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -137,7 +137,7 @@ public class TasksPage extends GenericPage {
     projectTitleElement().setTextValue(projectName);
     addManagerBtnElement().click();
     mentionInField(inviteProjectManagerInputElement(), fullName, 5);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -146,7 +146,7 @@ public class TasksPage extends GenericPage {
     projectTitleElement().setTextValue(projectName);
     addProjectManagerInput(manager);
     addProjectParticipantInput(participant);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -154,7 +154,7 @@ public class TasksPage extends GenericPage {
     addProjectOrTaskElement().click();
     projectTitleElement().setTextValue(projectName);
     addProjectParticipantInput(lastName);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -416,7 +416,7 @@ public class TasksPage extends GenericPage {
   }
 
   public void clickOnConfirmButton() {
-    confirmButtonDrawerElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void clickOnDeleteStatusIcon() {
@@ -568,7 +568,7 @@ public class TasksPage extends GenericPage {
   }
 
   public void clickSaveProjectButton() {
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
     waitForDrawerToClose();
   }
 
@@ -646,11 +646,11 @@ public class TasksPage extends GenericPage {
   }
 
   public void confirmFilter() {
-    confirmFilterButtonElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void confirmFilterButtonIsDisplayed() {
-    confirmFilterButtonElement().assertVisible();
+    primaryButtonDrawerElement().assertVisible();
   }
 
   public void deleteProject(String projectName) {
@@ -694,7 +694,7 @@ public class TasksPage extends GenericPage {
     projectThreeDotsButtonElement().click();
     editProjectButtonElement().click();
     projectTitleElement().setTextValue(projectName);
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void editProjectNameWithDescription(String projectName, String newProjectName, String newDescription) {
@@ -715,7 +715,7 @@ public class TasksPage extends GenericPage {
       getDriver().switchTo().defaultContent();
     }
 
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void editSpaceName(String spaceName) {
@@ -981,11 +981,11 @@ public class TasksPage extends GenericPage {
   }
 
   public void saveAddingProject() {
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void saveAddTaskButton() {
-    saveButtonElement().click();
+    primaryButtonDrawerElement().click();
   }
 
   public void saveQuickTask() {
@@ -1299,12 +1299,8 @@ public class TasksPage extends GenericPage {
     return findTextBoxByXPathOrCSS(")]");
   }
 
-  private ElementFacade confirmButtonDrawerElement() {
-    return findByXPathOrCSS("//*[@class='btn btn-primary v-btn v-btn--contained theme--light v-size--default']");
-  }
-
-  private ElementFacade confirmFilterButtonElement() {
-    return findByXPathOrCSS("//*[contains(@class,'filterSortTasksDrawer')]//following::*[contains(text(),'Confirm')]");
+  private ElementFacade primaryButtonDrawerElement() {
+    return findByXPathOrCSS("//*[contains(@class, 'v-navigation-drawer--open')]//*[contains(@class, 'drawerFooter')]//*[contains(@class, 'btn-primary')]");
   }
 
   private ElementFacade deleteButtonElement() {
@@ -1665,10 +1661,6 @@ public class TasksPage extends GenericPage {
 
   private ElementFacade resetFilterButtonElement() {
     return findByXPathOrCSS("//*[contains(@class,'filterSortTasksDrawer')]//following::*[contains(text(),'Reset')]");
-  }
-
-  private ElementFacade saveButtonElement() {
-    return findByXPathOrCSS("//*[@class='d-flex']//button[2]");
   }
 
   private ElementFacade saveButtonTaskElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/KudosSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/KudosSteps.java
@@ -118,22 +118,26 @@ public class KudosSteps {
   }
 
   public void checkCancelKudosCommentIsNotVisible(String activity, String kudos) {
-    spaceHomePage.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(kudos);
+    spaceHomePage.openCommentsDrawer(activity);
+    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(kudos, false);
     kudosPage.checkCancelKudosCommentIsNotVisible(kudos);
   }
 
   public void checkDeleteKudosCommentIsNotVisible(String activity, String kudos) {
-    spaceHomePage.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(kudos);
+    spaceHomePage.openCommentsDrawer(activity);
+    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(kudos, false);
     kudosPage.checkDeleteKudosCommentIsNotVisible(kudos);
   }
 
   public void checkDeleteKudosCommentIsVisible(String activity, String kudos) {
-    spaceHomePage.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(kudos);
+    spaceHomePage.openCommentsDrawer(activity);
+    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(kudos, false);
     kudosPage.checkDeleteKudosCommentIsVisible(kudos);
   }
 
   public void cancelCommentKudos(String activity, String comment) {
-    spaceHomePage.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(comment);
+    spaceHomePage.openCommentsDrawer(activity);
+    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment, false);
     kudosPage.cancelKudosComment(activity, comment);
     spaceHomePage.clickYesbutton();
   }

--- a/src/test/java/io/meeds/qa/ui/steps/SpaceHomeSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/SpaceHomeSteps.java
@@ -211,20 +211,8 @@ public class SpaceHomeSteps {
     spaceHomePage.clickOnCommentsDrawerSecondPage();
   }
 
-  public void clickOnCommentThreeDotsButton(String activity, String comment) {
-    spaceHomePage.clickOnCommentThreeDotsButton(activity, comment);
-  }
-
-  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment);
-  }
-
-  public void clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    spaceHomePage.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(comment);
-  }
-
-  public void clickOnCommentThreeDotsInCommentsDrawer(String comment) {
-    spaceHomePage.clickOnCommentThreeDotsInCommentsDrawer(comment);
+  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment, boolean reply) {
+    spaceHomePage.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment, reply);
   }
 
   public void clickOnKudosNumberButton() {
@@ -237,10 +225,6 @@ public class SpaceHomeSteps {
 
   public void clickOnLoadMoreActivities() {
     spaceHomePage.clickOnLoadMoreActivities();
-  }
-
-  public void clickOnReplyDropDownMenu(String activity, String comment, String reply) {
-    spaceHomePage.clickOnReplyDropDownMenu(activity, comment, reply);
   }
 
   public void clickOnReplyKudos(String reply) {
@@ -477,10 +461,6 @@ public class SpaceHomeSteps {
     spaceHomePage.openDeleteActivityMenu(activity);
   }
 
-  public void openDeleteCommentMenu(String activity, String comment) {
-    spaceHomePage.openDeleteCommentMenu(activity, comment);
-  }
-
   public void openEditActivityMenu(String activity) {
     spaceHomePage.openEditActivityMenu(activity);
   }
@@ -491,10 +471,6 @@ public class SpaceHomeSteps {
 
   public void openThreeDotsActivityMenu(String activity) {
     spaceHomePage.openThreeDotsActivityMenu(activity);
-  }
-
-  public void openThreeDotsCommentMenu(String comment) {
-    spaceHomePage.openThreeDotsCommentMenu(comment);
   }
 
   public void pinActivityButtonIsDisplayed(String activity) {

--- a/src/test/java/io/meeds/qa/ui/steps/definition/SpaceHomeStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/SpaceHomeStepDefinition.java
@@ -302,25 +302,15 @@ public class SpaceHomeStepDefinition {
     spaceHomeSteps.clickOnCommentsDrawerSecondPage();
   }
 
-  @Then("^In activity '(.*)', I click on the comment '(.*)' three dots icon$")
-  public void clickOnCommentThreeDotsButton(String activity, String comment) {
-    spaceHomeSteps.clickOnCommentThreeDotsButton(activity, comment);
-  }
-
   @Then("^I click on the comment '(.*)' three dots icon from comments drawer$")
-  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    spaceHomeSteps.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment);
-  }
-
   @And("^I click on the first comment '(.*)' three dots icon from comments drawer$")
-  public void clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(String comment) {
-    spaceHomeSteps.clickOnFirstCommentThreeDotsButtonFromCommentsDrawer(comment);
+  public void clickOnCommentThreeDotsButtonFromCommentsDrawer(String comment) {
+    spaceHomeSteps.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment, false);
   }
 
-  @Then("^In comments drawer, I click on the comment '(.*)' three dots icon$")
-  @And("^In comments drawer, I click on the reply '(.*)' three dots icon$")
-  public void clickOnCommentThreeDotsInCommentsDrawer(String comment) {
-    spaceHomeSteps.clickOnCommentThreeDotsInCommentsDrawer(comment);
+  @When("^I click on the reply '(.*)' three dots icon from comments drawer$")
+  public void clickOnReplyThreeDotsButtonFromCommentsDrawer(String comment) {
+    spaceHomeSteps.clickOnCommentThreeDotsButtonFromCommentsDrawer(comment, true);
   }
 
   @When("^I click on the internal link '(.*)'$")
@@ -331,11 +321,6 @@ public class SpaceHomeStepDefinition {
   @When("^I click on Load more button$")
   public void clickOnLoadMoreActivities() {
     spaceHomeSteps.clickOnLoadMoreActivities();
-  }
-
-  @Then("^In activity '(.*)' with comment '(.*)', I click on the reply '(.*)' three dots icon$")
-  public void clickOnReplyDropDownMenu(String activity, String comment, String reply) {
-    spaceHomeSteps.clickOnReplyDropDownMenu(activity, comment, reply);
   }
 
   @Then("^In reply '(.*)', I click on kudos button$")
@@ -728,11 +713,6 @@ public class SpaceHomeStepDefinition {
     spaceHomeSteps.openDeleteActivityMenu(oldActiviyy);
   }
 
-  @When("^In activity '(.*)' I delete the comment '(.*)'$")
-  public void openDeleteCommentMenu(String activity, String comment) {
-    spaceHomeSteps.openDeleteCommentMenu(activity, comment);
-  }
-
   @When("^I click on modify the activity$")
   public void openEditActivityMenu() {
     String oldActiviyy = Serenity.sessionVariableCalled("activity");
@@ -757,11 +737,6 @@ public class SpaceHomeStepDefinition {
   @When("^I click on three dots button related to activity '(.*)'$")
   public void openThreeDotsActivityMenu(String activity) {
     spaceHomeSteps.openThreeDotsActivityMenu(activity);
-  }
-
-  @When("^I click on three dots button related to comment '(.*)'$")
-  public void openThreeDotsCommentMenu(String comment) {
-    spaceHomeSteps.openThreeDotsCommentMenu(comment);
   }
 
   @When("^Pin button related to activity '(.*)' is displayed$")

--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -434,7 +434,8 @@ Feature: Achievements
     And I publish the activity
     Then the activity 'Activity with comment to cancel' is displayed in activity stream
     When I add in activity 'Activity with comment to cancel' a comment 'comment to delete'
-    And In activity 'Activity with comment to cancel', I click on the comment 'comment to delete' three dots icon
+    And I open in activity 'Activity with comment to cancel' the Comments drawer
+    And I click on the comment 'comment to delete' three dots icon from comments drawer
     And In comment 'comment to delete', I click on delete button
     And I click on Yes button
     Then the confirmation popup is not displayed

--- a/src/test/resources/features/Gamification/Actions.feature
+++ b/src/test/resources/features/Gamification/Actions.feature
@@ -327,8 +327,8 @@ Feature: Actions
 
     And I close the opened drawer
     And I announce challenge 'Announce activity to delete' with message 'announcement11' from activity
-    Then The comment 'announcement11' is displayed
-    And I click on three dots button related to comment 'announcement11'
+    And I open in activity 'Announce activity to delete' the Comments drawer
+    And I click on the comment 'announcement11' three dots icon from comments drawer
     And I click on 'Cancel' button related to comment 'announcement11'
     And I click on Yes button
 

--- a/src/test/resources/features/Social/Activities.feature
+++ b/src/test/resources/features/Social/Activities.feature
@@ -13,7 +13,7 @@ Feature: Activities
     Then the confirmation popup is not displayed
     And the activity 'activity to delete' is no more displayed in the activity stream
 
-  Scenario:  delete your comment
+  Scenario: delete your comment
     Given I am authenticated as 'admin' random user
     And I inject a random space
     And I go to the random space
@@ -24,7 +24,11 @@ Feature: Activities
     When I add in activity 'activity with comment to delete' a comment 'A comment to delete'
     And I open in activity 'activity with comment to delete' the Comments drawer
     Then The comment 'A comment to delete' is displayed in Comments drawer of activity 'activity with comment to delete'
-    When In activity 'activity with comment to delete' I delete the comment 'A comment to delete'
+
+    When I open in activity 'activity with comment to delete' the Comments drawer
+    And I click on the comment 'A comment to delete' three dots icon from comments drawer
+    And In comment 'A comment to delete', I click on delete button
+
     And I click on Yes button
     Then the confirmation popup is not displayed
     And The comment 'A comment to delete' is not displayed in Comments drawer of activity 'activity with comment to delete'

--- a/src/test/resources/features/Social/ActivityStream.feature
+++ b/src/test/resources/features/Social/ActivityStream.feature
@@ -2,7 +2,7 @@
 
 Feature: Activity Stream
 
-  Scenario: CAP04 - [ActivityStream_US05] Display 10 activities in Activity Stream
+  Scenario: Display 10 activities in Activity Stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second |
@@ -59,7 +59,7 @@ Feature: Activity Stream
     Then the activity 'act_CAP04_6' is displayed in activity stream
     Then the activity 'act_CAP04_1' is displayed in activity stream
 
-  Scenario: CAP100 - [ActivityStream_US38][04] Cancel Delete comment with replies from the activity stream
+  Scenario: Cancel Delete comment with replies from the activity stream
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second |
@@ -122,7 +122,7 @@ Feature: Activity Stream
     And In activity 'activityTestCAP100-100' with comment 'commenttestCAP100-100', the reply 'replyTestCAP100-100' is displayed
     And In activity 'activityTestCAP100-100' with comment 'commenttestCAP100-100', the reply 'replyTestCAP100-101' is displayed
 
-  Scenario: CAP102 - [ActivityStream_US38][06] Cancel Delete a reply from the activity stream
+  Scenario: Cancel Delete a reply from the activity stream
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -199,9 +199,8 @@ Feature: Activity Stream
     And In comment 'commenttestCAP102-102', the reply 'replyTestCAP102-102' is not displayed in the drawer
     And In comment 'commenttestCAP102-102', the reply 'replyTestCAP102-103' is displayed in the drawer
     And In comment 'commenttestCAP102-102', the reply 'replyTestCAP102-104' is displayed in the drawer
-    And I close the opened drawer
 
-    When In activity 'activityTestCAP102-102' with comment 'commenttestCAP102-102', I click on the reply 'replyTestCAP102-103' three dots icon
+    When I click on the reply 'replyTestCAP102-103' three dots icon from comments drawer
     And In reply 'replyTestCAP102-103', I click on delete button
     And I click on Cancel button
     Then the confirmation popup is not displayed
@@ -211,7 +210,7 @@ Feature: Activity Stream
     And In comment 'commenttestCAP102-102', the reply 'replyTestCAP102-103' is displayed in the drawer
     And In comment 'commenttestCAP102-102', the reply 'replyTestCAP102-104' is displayed in the drawer
 
-  Scenario: CAP103 - [ActivityStream_US39][01] Delete a simple comment from the comment drawer
+  Scenario: Delete a simple comment from the comment drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -254,7 +253,8 @@ Feature: Activity Stream
 
     When I open in activity 'activityTestCAP103-103' the Comments drawer
     Then '1 comment', only 'commenttestCAP103-103' is displayed in Comments drawer
-    When In comments drawer, I click on the comment 'commenttestCAP103-103' three dots icon
+    And I open in activity 'activityTestCAP103-103' the Comments drawer
+    And I click on the comment 'commenttestCAP103-103' three dots icon from comments drawer
     And In comment 'commenttestCAP103-103', I click on delete button
     And I click on Yes button
     Then the confirmation popup is not displayed
@@ -285,7 +285,7 @@ Feature: Activity Stream
     When I close the opened drawer
     Then The comment 'commenttestCAP104-CAP103-103' is not displayed in Comments drawer of activity 'activityTestCAP103-103'
 
-  Scenario: CAP104 - [ActivityStream_US39][02] Cancel Delete a simple comment from the comment drawer
+  Scenario: Cancel Delete a simple comment from the comment drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -328,7 +328,8 @@ Feature: Activity Stream
 
     When I open in activity 'activityTestCAP104-104' the Comments drawer
     Then '1 comment', only 'commenttestCAP104-104' is displayed in Comments drawer
-    When In comments drawer, I click on the comment 'commenttestCAP104-104' three dots icon
+    And I open in activity 'activityTestCAP104-104' the Comments drawer
+    And I click on the comment 'commenttestCAP104' three dots icon from comments drawer
     And In comment 'commenttestCAP104-104', I click on delete button
     And I click on Cancel button
     Then the confirmation popup is not displayed
@@ -350,7 +351,7 @@ Feature: Activity Stream
     When I open in activity 'activityTestCAP104-104' the Comments drawer
     Then '1 comment', only 'commenttestCAP104-104' is displayed in Comments drawer
 
-  Scenario: CAP105 - [ActivityStream_US39][03] Delete comment with replies from the comment drawer
+  Scenario: Delete comment with replies from the comment drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -415,7 +416,8 @@ Feature: Activity Stream
     Then In comment 'commenttestCAP105-105', the reply 'replyTest101' is displayed in the drawer
     And In comment 'commenttestCAP105-105', the reply 'replyTest102' is displayed in the drawer
     And In comment 'commenttestCAP105-105', the reply 'replyTest103' is displayed in the drawer
-    When In comments drawer, I click on the comment 'commenttestCAP105-105' three dots icon
+    And I open in activity 'activityTestCAP105-105' the Comments drawer
+    And I click on the comment 'commenttestCAP105-105' three dots icon from comments drawer
     And In comment 'commenttestCAP105-105', I click on delete button
     And I click on Yes button
     Then the confirmation popup is not displayed
@@ -455,7 +457,7 @@ Feature: Activity Stream
     When I close the opened drawer
     Then The comment 'commenttestCAP105-105' is not displayed in Comments drawer of activity 'activityTestCAP105-105'
 
-  Scenario: CAP106 - [ActivityStream_US39][04] Cancel Delete comment with replies from the comments drawer
+  Scenario: Cancel Delete comment with replies from the comments drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -521,7 +523,7 @@ Feature: Activity Stream
     Then In comment 'commenttestCAP106-106', the reply 'replyTestCAP106-101' is displayed in the drawer
     And In comment 'commenttestCAP106-106', the reply 'replyTestCAP106-102' is displayed in the drawer
     And In comment 'commenttestCAP106-106', the reply 'replyTestCAP106-103' is displayed in the drawer
-    When In comments drawer, I click on the comment 'commenttestCAP106-106' three dots icon
+    When I click on the comment 'commenttestCAP106-106' three dots icon from comments drawer
     And In comment 'commenttestCAP106-106', I click on delete button
     And I click on Cancel button
     Then the confirmation popup is not displayed
@@ -554,7 +556,7 @@ Feature: Activity Stream
     And In comment 'commenttestCAP106-106', the reply 'replyTestCAP106-102' is displayed in the drawer
     And In comment 'commenttestCAP106-106', the reply 'replyTestCAP106-103' is displayed in the drawer
 
-  Scenario: CAP107 - [ActivityStream_US39][05] Delete a reply from comments drawer
+  Scenario: Delete a reply from comments drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -616,7 +618,7 @@ Feature: Activity Stream
     Then In comment 'commenttestCAP107-107', the reply 'replyTestCAP107-101' is displayed in the drawer
     And In comment 'commenttestCAP107-107', the reply 'replyTestCAP107-102' is displayed in the drawer
     And In comment 'commenttestCAP107-107', the reply 'replyTestCAP107-103' is displayed in the drawer
-    When In comments drawer, I click on the reply 'replyTestCAP107-102' three dots icon
+    When I click on the reply 'replyTestCAP107-102' three dots icon from comments drawer
     And In reply 'replyTestCAP107-102', I click on delete button
     And I click on Yes button
     Then the confirmation popup is not displayed
@@ -663,7 +665,7 @@ Feature: Activity Stream
     And In activity 'activityTestCAP107-107' with comment 'commenttestCAP107-107', the reply 'replyTestCAP107-103' is displayed in Comment Drawer
     And In activity 'activityTestCAP107-107' with comment 'commenttestCAP107-107', the reply 'replyTestCAP107-102' is not displayed
 
-  Scenario: CAP108 - [ActivityStream_US39][06] Cancel Delete a reply from the comments drawer
+  Scenario: Cancel Delete a reply from the comments drawer
     Given I am authenticated as 'admin' if random space and random users doesn't exists
       | first  |
       | second  |
@@ -727,7 +729,7 @@ Feature: Activity Stream
     Then In comment 'commenttestCAP108-108', the reply 'replyTestCAP108-101' is displayed in the drawer
     And In comment 'commenttestCAP108-108', the reply 'replyTestCAP108-102' is displayed in the drawer
     And In comment 'commenttestCAP108-108', the reply 'replyTestCAP108-103' is displayed in the drawer
-    When In comments drawer, I click on the reply 'replyTestCAP108-102' three dots icon
+    When I click on the reply 'replyTestCAP108-102' three dots icon from comments drawer
     And In reply 'replyTestCAP108-102', I click on delete button
     And I click on Cancel button
     Then the confirmation popup is not displayed
@@ -779,7 +781,7 @@ Feature: Activity Stream
     And In activity 'activityTestCAP108-108' with comment 'commenttestCAP108-108', the reply 'replyTestCAP108-102' is displayed in Comment Drawer
     And In activity 'activityTestCAP108-108' with comment 'commenttestCAP108-108', the reply 'replyTestCAP108-103' is displayed in Comment Drawer
 
-  Scenario: CAP109 - [ActivityStream_US40][01] Like my comment/reply from activity stream
+  Scenario: Like my comment/reply from activity stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -854,7 +856,7 @@ Feature: Activity Stream
     Then In comments drawer, in comment 'commenttestCAP110-110', Like label should be black
     And In comments drawer, on comment 'commenttestCAP110-110', '(0)' like is displayed
 
-  Scenario: CAP111 - [ActivityStream_US40][03] Like comment/reply of other user from activity stream
+  Scenario: Like comment/reply of other user from activity stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -903,7 +905,7 @@ Feature: Activity Stream
     When In comments drawer, in comment 'commenttest111', I hover on Like icon
     Then Tooltip Remove Like on 'commenttest111' is displayed in comments drawer
 
-  Scenario: CAP112 [ActivityStream_US40][04] Unlike comment/reply of other user from activity stream
+  Scenario: Unlike comment/reply of other user from activity stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -946,7 +948,7 @@ Feature: Activity Stream
     Then In comments drawer, in comment 'commenttestCAP112-112', Like label should be black
     And In comments drawer, on comment 'commenttestCAP112-112', '(0)' like is displayed
 
-  Scenario: CAP115 - [ActivityStream_US41][01] Like my comment/reply from the comment drawer
+  Scenario: Like my comment/reply from the comment drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -990,7 +992,7 @@ Feature: Activity Stream
     And Tooltip Remove Like on 'commenttest115' is displayed in comments drawer
     And I close the opened drawer
 
-  Scenario: CAP116 - [ActivityStream_US41][02] Unlike my comment/reply from the comments drawer
+  Scenario: Unlike my comment/reply from the comments drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1029,7 +1031,7 @@ Feature: Activity Stream
     And In comments drawer, on comment 'commenttestCAP116-116', '(0)' like is displayed
     And I close the opened drawer
 
-  Scenario: CAP157 - [ActivityStream_IMPV15][01] Internal Link opening behaviors inside comments
+  Scenario: Internal Link opening behaviors inside comments
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1062,7 +1064,7 @@ Feature: Activity Stream
     And I open the internal link '/members' in new tab
     Then The internal link '/members' is opened in new tab
 
-  Scenario: CAP158 - [ActivityStream_IMPV15][02] External Link opening behaviors inside comments
+  Scenario: External Link opening behaviors inside comments
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1141,7 +1143,7 @@ Feature: Activity Stream
     Then the confirmation popup is not displayed
     And The comment 'commenttest97' is not displayed in Comments drawer of activity 'activityTest97'
 
-  Scenario: Cap155 - ActivityStream_US58: Mention a user in the comments
+  Scenario: Mention a user in the comments
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1259,7 +1261,7 @@ Feature: Activity Stream
     And In activity 'activityTest147' with comment 'commenttest147', the reply 'replyTest147' is displayed
     And I go to the home page
 
-  Scenario: CAP20 - [ActivityStream_US10][09] Activity with text or link options (3 dots) (Author delete the post)
+  Scenario: Activity with text or link options (3 dots) (Author delete the post)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1288,7 +1290,7 @@ Feature: Activity Stream
     When I go to Stream page
     Then the activity 'activityus1009cap20' is not displayed in stream page
 
-  Scenario: CAP21 - [ActivityStream_US10][10] Activity with text or link options (3 dots) ( Author cancel delete post)
+  Scenario: Activity with text or link options (3 dots) ( Author cancel delete post)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1317,7 +1319,7 @@ Feature: Activity Stream
     When I go to Stream page
     Then the activity 'activityus1010cap21' is displayed in stream page
 
-  Scenario: CAP88 - [ActivityStream_US04.1][01] Edit comment from the comment drawer
+  Scenario: Edit comment from the comment drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1374,7 +1376,7 @@ Feature: Activity Stream
     And I open in activity 'activitycap88' the Comments drawer
     Then Comment is displayed in comments drawer at the sixth position
 
-  Scenario: CAP128 - [ActivityStream_US47][01] Send a kudos from a comment
+  Scenario: Send a kudos from a comment
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1413,7 +1415,7 @@ Feature: Activity Stream
     And I click on the kudos button number
     Then '1' kudos are displayed on the reaction drawer
 
-  Scenario: CAP129 - [ActivityStream_US47][03] Send a kudos from the comments drawer
+  Scenario: Send a kudos from the comments drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | sixth  |
@@ -1449,7 +1451,7 @@ Feature: Activity Stream
     And I click on the kudos button number from the comments drawer
     Then '1' kudos are displayed on the reaction drawer
 
-  Scenario: CAP220 - [ActivityStream_IMPV07][01] Pagination in comments drawer
+  Scenario: Pagination in comments drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
 
@@ -1508,7 +1510,7 @@ Feature: Activity Stream
     And Comment 'commenttestCAP220-1020' is not displayed in the drawer
     Then Check Four comment is displayed in comments drawer
     
-  Scenario: [STREAM-12] Activity Likers in drawer
+  Scenario: Activity Likers in drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | sixth  |
@@ -1553,7 +1555,7 @@ Feature: Activity Stream
     And I open user profile of sixth user from activity likers drawer
     And The page '/profile' is opened
 
-  Scenario: CAP129 - [ActivityStream_US47][02] Send a kudos from a reply
+  Scenario: Send a kudos from a reply
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | sixth  |
@@ -1599,7 +1601,7 @@ Feature: Activity Stream
     When I click on the kudos button number
     Then '1' kudos are displayed on the reaction drawer
 
-  Scenario: CAP89 - [ActivityStream_US04][03] Edit reply in Activity stream
+  Scenario: Edit reply in Activity stream
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1649,14 +1651,15 @@ Feature: Activity Stream
     And I click on comment button related to activity 'activitycap87'
     Then Fourth comment is displayed in comments drawer
 
-    When In activity 'activitycap87', I click on the comment 'commenttest104' three dots icon
+    When I open in activity 'activitycap87' the Comments drawer
+    And I click on the comment 'commenttest104' three dots icon from comments drawer
     And In comment 'commenttest104', I click on edit button
     And I update comment with a new one 'commenttestupdated104'
     And I click on update comment
     And I open in activity 'activitycap87' the Comments drawer
     Then Fourth comment is displayed in comments drawer
 
-  Scenario: [ActivityStream_US52][03] Edit a kudos from a comment
+  Scenario: Edit a kudos from a comment
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1690,7 +1693,7 @@ Feature: Activity Stream
     And I set the new kudos comment text 'updated kudos message' and I click on update button
     Then the updated Kudos activity 'updated kudos message' is displayed in stream page
 
-  Scenario: [ActivityStream_US52][05] Edit a kudos from a reply
+  Scenario: Edit a kudos from a reply
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1739,7 +1742,7 @@ Feature: Activity Stream
     And I set the new kudos comment text 'updated kudos message' and I click on update button
     Then the updated Kudos activity 'updated kudos message' is displayed in stream page
 
-  Scenario: CAP132 - [ActivityStream_US52][01] Edit a kudos comment from an activity
+  Scenario: Edit a kudos comment from an activity
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | fifth  |
@@ -1766,7 +1769,7 @@ Feature: Activity Stream
     And I set the new kudos comment text 'updated Test Auto reply Kudos US52_01' and I click on update button
     Then the updated Kudos activity 'updated Test Auto reply Kudos US52_01' is displayed in stream page
 
-  Scenario: PinActivity_US01: Space host or redactor can pin an activity (from Space Stream -  Space host Case)
+  Scenario: Space host or redactor can pin an activity (from Space Stream -  Space host Case)
     Given I am authenticated as 'admin' random user
     And I create a random space
     And I go to the random space
@@ -1785,7 +1788,7 @@ Feature: Activity Stream
     Given I click on three dots button related to activity 'PinTest'
     Then Unpin button related to activity 'PinTest' is displayed
 
-  Scenario: Pin Activity US01: Space host or redactor can pin an activity (from General Stream -  Space redactor Case)
+  Scenario: Space host or redactor can pin an activity (from General Stream -  Space redactor Case)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1818,7 +1821,7 @@ Feature: Activity Stream
     Given I click on three dots button related to activity 'PinTest'
     Then Unpin button related to activity 'PinTest' is displayed
 
-  Scenario: Pin Activity US03: Unpin an activity
+  Scenario: Unpin an activity
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
       | second  |
@@ -1855,7 +1858,7 @@ Feature: Activity Stream
     When I close the notification
     Then The activity 'PinTest' should be not pinned in space stream
 
-  Scenario: Pin Activity US04: Pinned activities filter
+  Scenario: Pinned activities filter
     Given I am authenticated as 'admin' random user
     And I create a random space
     And I click on post in space

--- a/src/test/resources/features/Tasks/Tasks.feature
+++ b/src/test/resources/features/Tasks/Tasks.feature
@@ -2,7 +2,7 @@
 Feature: Tasks
 
   @smoke
-  Scenario: CAP81 - [User_UI_US22] Mark as completed for "TASKS" in a Project (Manager case)
+  Scenario: Mark as completed for "TASKS" in a Project (Manager case)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I inject the first random user if not existing
@@ -20,7 +20,7 @@ Feature: Tasks
     And Tasks number '0' is displayed in the column To Do
 
   @smoke
-  Scenario: CAP176 - [US_Filterfield_01] Add Clear typed characters icon (Filter by task under TASKS tab)
+  Scenario: Add Clear typed characters icon (Filter by task under TASKS tab)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I inject the first random user if not existing
@@ -37,7 +37,7 @@ Feature: Tasks
     And The clear button is disappeared from Filter by task field
 
   @smoke
-  Scenario: CAP94_[Add_Task_Drawer_US04] (3 dots menu-Delete action) "Tasks TAB"
+  Scenario: (3 dots menu-Delete action) "Tasks TAB"
     Given I am authenticated as 'admin' random user
 
     And I go to 'tasks' in site 'mycraft'
@@ -52,7 +52,7 @@ Feature: Tasks
     And I close the opened drawer
     Then Task '<TestE>' is deleted successfully
 
-  Scenario: CAP82 - [User_UI_US22] Mark as completed for "TASKS" in a Project (Participant case)
+  Scenario: Mark as completed for "TASKS" in a Project (Participant case)
     Given I am authenticated as 'admin' random user
     And I inject the first random user if not existing
 
@@ -76,7 +76,7 @@ Feature: Tasks
 
   @smoke
   @standardConfigurationOnly
-  Scenario: CAP95 - [Add_Task_Drawer_US04] 3 dots menu (Delete action) "Task under project"
+  Scenario: 3 dots menu (Delete action) "Task under project"
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I inject the first random user if not existing
@@ -128,7 +128,7 @@ Feature: Tasks
     And I set task due date TODAY
     And I close the opened drawer
 
-  Scenario: CAP188 - [Lost Projects] check that project isn't lost after renaming space name
+  Scenario: check that project isn't lost after renaming space name
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I inject the first random user if not existing
@@ -190,7 +190,7 @@ Feature: Tasks
     Then In column status 'TestStatus2' , Task name 'Collaboration FT Task' is displayed
 
   @smoke
-  Scenario: CAP269 - [US_Sharedlabels_02] Manage labels in Project
+  Scenario: Manage labels in Project
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And I inject the first random user if not existing
@@ -247,7 +247,7 @@ Feature: Tasks
     And Task name 'taskE' is not displayed in project details
     And Tasks number '0' is displayed in the column To Do
 
-  Scenario: CAP264 - [NF] [US_Sharedlabels_01]All project members can use added labels
+  Scenario: All project members can use added labels
     Given I am authenticated as 'admin' random user
     And I inject the first random user if not existing, no wait
     And I inject the second random user if not existing
@@ -331,7 +331,7 @@ Feature: Tasks
     Then Third user with the task comment 'Start working on it' is displayed in task comments drawer
 
   @smoke
-  Scenario: CAP190 -[IMP] [US_SortGroupeBy_01] Memorize Group and Sort filters (Group by)
+  Scenario: Memorize Group and Sort filters (Group by)
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And  I inject the first random user if not existing
@@ -369,7 +369,7 @@ Feature: Tasks
     Then I check that grouping 'assignee' is selected
     And I refresh the page
     
-  Scenario: CAP341 [TASK] when refresh task drawer, the description should not be lost
+  Scenario: when refresh task drawer, the description should not be lost
     Given I am authenticated as 'admin' random user
     And I inject the first random user if not existing
 
@@ -400,7 +400,7 @@ Feature: Tasks
     When I refresh the page
     Then The edit description in the task 'Edit Automation Test Task' is displayed
 
-  Scenario: [IMP] [US_ChangesDrawer_01] Display last Update and Changes drawer
+  Scenario: Display last Update and Changes drawer
     Given I am authenticated as 'admin' if random users doesn't exists
       | first  |
     And  I inject the first random user if not existing
@@ -455,7 +455,7 @@ Feature: Tasks
     And I open the task 'Automation Test Task'
     Then The update description 'Decription Task updated' is displayed in origin task
 
-  Scenario: CAP37 - [User_UI_US18.1] Check message when project title contains less than 3 characters
+  Scenario: Check message when project title contains less than 3 characters
     Given I am authenticated as 'admin' random user
     And I go To AppCenter Drawer
     And I open all application page


### PR DESCRIPTION
Prior to this change, the following test cases fails: Programs Overview Widget sorted by modified date
Cancel Delete a reply from the activity stream
Cancel an announcement
Achievements listing for program owner/space host
Memorize Group and Sort filters (Group by)
This change will fix them by changing XPath.