### PR TITLE
fix: Fix Access to App Center Menu - MEED-7339 - Meeds-io/MIPs#134

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -249,12 +249,12 @@ public class HomePage extends GenericPage {
     goToAdministrationPage("general/mainsettings", true);
   }
 
-  public void goToAppCenterAdminSetupPage() {
-    goToAdministrationPage("general/applicationsCenter");
-  }
-
   public void goToNotificationAdminPage() {
     goToAdministrationPage("general/notification");
+  }
+
+  public void goToAppCenterAdminSetupPage() {
+    goToAdministrationPage("applications/applicationsCenter");
   }
 
   public void goToHomePage() {
@@ -512,6 +512,9 @@ public class HomePage extends GenericPage {
   private void goToAdministrationPage(String uri, boolean forceRefresh) {
     if (forceRefresh || !StringUtils.contains(getDriver().getCurrentUrl(), uri)) {
       accessToAdministrationMenu();
+      administrationMenuItem(uri).checkEnabled();
+      administrationMenuItem(uri).scrollToWebElement();
+      administrationMenuItem(uri).checkVisible();
       administrationMenuItem(uri).click();
       waitForPageLoading();
     }

--- a/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
+++ b/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
@@ -53,7 +53,9 @@ public class TestInitHook {
 
   public static final String              ADMIN_PREFIX              = "admin";
 
-  public static final String              ADMIN_USERNAME            = System.getProperty("adminUser", "admin");
+  public static final String              URL                       = System.getProperty("webdriver.base.url", "http://localhost:8080/");
+
+  public static final String              ADMIN_USERNAME            = System.getProperty("adminUser", ADMIN_PREFIX);
 
   public static final String              ADMIN_PASSWORD            = System.getProperty("adminPassword", "Test1234@");
 
@@ -242,7 +244,7 @@ public class TestInitHook {
                   retryCount,
                   MAX_WARM_UP_RETRIES);
       try {
-        driver.navigate().to(System.getProperty("webdriver.base.url"));
+        driver.navigate().to(URL);
         Utils.waitForLoading(WARM_UP_PAGE_LOADING_WAIT, true);
         driver.navigate().refresh();
         loginSteps.waitForUsernameInputDisplay(MAX_WARM_UP_RETRIES);


### PR DESCRIPTION
Prior to this change, the AppCenter menu wasn't accessed through its new location in the new parent "applications". This change changes the parent node of AppCenter Administration menu entry.