### PR TITLE
fix: Fix Kudos Test Case and Disable PWA Snackbar - Meeds-io/MIPs#155

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
     <!-- Specific target snapshot repository -->
     <exo.snapshots.repo.url>https://repository.exoplatform.org/content/repositories/meeds-snapshots</exo.snapshots.repo.url>
+   <timestamp>${maven.build.timestamp}</timestamp>
+   <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -198,7 +200,7 @@
             <!-- Max retry when getting element -->
             <io.meeds.retry.max>${io.meeds.retry.max}</io.meeds.retry.max>
             <!-- Max implicit timeout for each retry on element fetching -->
-            <io.meeds.warmUp.file>${project.build.directory}/warmUp.tmp</io.meeds.warmUp.file>
+            <io.meeds.warmUp.file>${project.build.directory}/warmUp-${timestamp}.tmp</io.meeds.warmUp.file>
             <io.meeds.page.loading.wait>${io.meeds.page.loading.wait}</io.meeds.page.loading.wait>
             <io.meeds.retry.wait.millis>${io.meeds.retry.wait.millis}</io.meeds.retry.wait.millis>
             <io.meeds.forkNumber>${surefire.forkNumber}</io.meeds.forkNumber>

--- a/src/main/java/io/meeds/qa/ui/pages/UserProfilePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/UserProfilePage.java
@@ -411,11 +411,11 @@ public class UserProfilePage extends GenericPage {
   }
 
   private ElementFacade contactReceivedKudosElement() {
-    return findByXPathOrCSS("//*[@id='kudosOverviewCardsParent']//*[@class='kudosOverviewCard col'][1]//*[contains(@class, 'kudosOverviewCount')]");
+    return findByXPathOrCSS("//*[@id='kudosOverviewCardsParent']//*[contains(@class, 'kudosOverviewCard')][1]//*[contains(@class, 'kudosOverviewCount')]");
   }
 
   private ElementFacade contactSentKudosElement() {
-    return findByXPathOrCSS("//*[@id='kudosOverviewCardsParent']//*[@class='kudosOverviewCard col'][2]//*[contains(@class, 'kudosOverviewCount')]");
+    return findByXPathOrCSS("//*[@id='kudosOverviewCardsParent']//*[contains(@class, 'kudosOverviewCard')][2]//*[contains(@class, 'kudosOverviewCount')]");
   }
 
   private ElementFacade contactUrlTitleButtonElement() {
@@ -477,7 +477,7 @@ public class UserProfilePage extends GenericPage {
   }
 
   private ElementFacade getReceivedKudosUsers(String user) {
-    return findByXPathOrCSS(String.format("//*[contains(@class,'kudosOverviewDrawer')]//*[contains(@class,'drawerTitle') and contains(text(),'Kudos Received')]/following::*[contains(@id,'avatar') and contains(text(),'%s')]",
+    return findByXPathOrCSS(String.format("//*[contains(@class,'kudosOverviewDrawer')]//*[contains(text(),'%s')]",
                                           user));
   }
 
@@ -491,7 +491,7 @@ public class UserProfilePage extends GenericPage {
   }
 
   private ElementFacade getSentKudosUsers(String user) {
-    return findByXPathOrCSS(String.format("//*[contains(@class,'kudosOverviewDrawer')]//*[contains(@class,'drawerTitle') and contains(text(),'Kudos Sent')]/following::*[contains(@id,'avatar') and contains(text(),'%s')]",
+    return findByXPathOrCSS(String.format("//*[contains(@class,'kudosOverviewDrawer')]//*[contains(text(),'%s')]",
                                           user));
   }
 

--- a/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
+++ b/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
@@ -274,8 +274,10 @@ public class TestInitHook {
 
     addAdminRandomUser();
     manageSpaceSteps.configureSpaceCreationPermission();
+    genericSteps.disablePwa();
     loginAsRandomAdmin();
     if (INIT_DATA) {
+      LOGGER.info("---- FOR LOCAL TESTS, disable WARMUP Phase (used to improve global test execution time only) by adding \n\n\t\t******* -Dio.meeds.initData=false ******* \n\n\n");
       injectSpaces();
       injectUsers();
     }

--- a/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
@@ -17,12 +17,40 @@
  */
 package io.meeds.qa.ui.steps;
 
+import static io.meeds.qa.ui.utils.Utils.SHORT_WAIT_DURATION_MILLIS;
+
+import java.time.Duration;
 import java.util.Map;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import io.meeds.qa.ui.pages.GenericPage;
 
+import net.serenitybdd.core.Serenity;
+
 public class GenericSteps {
-  private GenericPage genericPage;
+  private static final String DISABLE_PWA_SCRIPT =
+                                                 """
+                                                      const callback = arguments[arguments.length - 1];
+                                                      fetch("/pwa/rest/manifest", {
+                                                        "headers": {
+                                                          "content-type": "application/json",
+                                                        },
+                                                        "body": `{"enabled":false,"name":"Web3 Hub","description":"Your Application for Communication, Collaboration, Teamwork and Engagement","themeColor":"#BC99E7","backgroundColor":"#BC99E7"}`,
+                                                        "method": "PUT",
+                                                        "credentials": "include"
+                                                      })
+                                                     .then(resp => {
+                                                       if (!resp || !resp.ok) {
+                                                         throw new Error("Error changing space creation permissions");
+                                                       }
+                                                     })
+                                                     .then(() => callback(true))
+                                                     .catch(() => callback(false));
+                                                      """;
+
+  private GenericPage         genericPage;
 
   public void checkConfirmMessageIsDisplayed(String message) {
     genericPage.checkConfirmMessageIsDisplayed(message);
@@ -206,6 +234,15 @@ public class GenericSteps {
 
   public void sortTableByField(String fieldText) {
     genericPage.sortTableByField(fieldText);
+  }
+
+  public void disablePwa() {
+    WebDriverWait wait = new WebDriverWait(Serenity.getDriver(),
+                                           Duration.ofSeconds(10),
+                                           Duration.ofMillis(SHORT_WAIT_DURATION_MILLIS));
+    wait.until(webDriver -> ((JavascriptExecutor) webDriver).executeAsyncScript(DISABLE_PWA_SCRIPT)
+                                                            .toString()
+                                                            .equals("true"));
   }
 
 }


### PR DESCRIPTION
This change will:
1. Fix Kudos Test Case XPath expression
2. Disable PWA Snackbar (displayed after few seconds of page display) which may cause a random tests fail
3. Add an informative log for developers to know how to disabled the warmup phase which will improve `Single Test Execution Time`
4. Generate new name for warmup file to ensure not having name collision between tests executions when not using `clean` directive in `mvn` command line