### PR TITLE
fix: Fix Access to Achievements Tabs - MEED-7362 - Meeds-io/meeds#2427

### DIFF
--- a/src/test/resources/features/Gamification/Achievement.feature
+++ b/src/test/resources/features/Gamification/Achievement.feature
@@ -67,7 +67,7 @@ Feature: Achievements
     When I go to the random space
     And I send in the activity 'Achievements - Kudos Post activity' a kudos message 'Achievements - kudos activity comment to cancel'
 
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Send kudos 6' is accepted
 
     When I go to My Profile page
@@ -77,11 +77,11 @@ Feature: Achievements
     And I open in activity 'Achievements - Kudos Post activity' the Comments drawer
     When In activity 'Achievements - Kudos Post activity' I cancel the sent kudos comment 'Achievements - kudos activity comment to cancel'
 
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Send kudos 6' is canceled
 
     When I login as 'secondachievement' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     And Achievement for 'Receive kudos 6' is canceled
 
   Scenario: Achievements for Send/Cancel Kudos from user profile
@@ -144,17 +144,17 @@ Feature: Achievements
     And I go to the fourachievement user profile
     And I send kudos with message 'Achievements - Kudos Post activity to cancel'
 
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Send kudos 86' is accepted
 
     And I go to Stream page
     When I cancel the sent kudos activity 'Achievements - Kudos Post activity to cancel'
 
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Send kudos 86' is canceled
 
     When I login as 'fourachievement' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Receive kudos 86' is canceled
 
   Scenario: Achievements listing for program owner/space host
@@ -213,7 +213,7 @@ Feature: Achievements
     And Admin Actions Filter dropdown is not displayed
 
     When I login as 'admin' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
 
     Then The achievement 'Join space' is displayed '2' times when enabling program owner view for 'Test Program Host' random program
 
@@ -222,7 +222,7 @@ Feature: Achievements
     And I promote 'fifthachievement' random user as a space manager
 
     When I login as 'sixthachievement' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then The achievement 'Join space' is displayed '1' times
     And The button 'Review' is not displayed
 
@@ -238,7 +238,7 @@ Feature: Achievements
     Then In drawer, user 'fifthachievement' achievement is display 'second'
 
     When I close the opened drawer
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     And I filter achievements using 'Test Program Host' random program
     Then The achievement 'Join space' is displayed '1' times
     And The button 'Review' is displayed
@@ -308,13 +308,13 @@ Feature: Achievements
     When I open 'Test Program Achievements sort' random program card
     And I announce challenge 'Announce an achievement' with message 'announcement2'
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     When I filter achievements using 'Test Program Achievements sort' random program
     And Current user achievement 'Announce an achievement' is displayed 'first'
     And Current user achievement 'Join space' is displayed 'second'
 
     When I login as 'admin' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
 
     When I click on 'Review' button
     Then I wait for application loading
@@ -401,7 +401,7 @@ Feature: Achievements
     And I click on Yes button
     Then the confirmation popup is not displayed
     And the activity 'Activity to cancel' is no more displayed in the activity stream
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Post activity in a space' is rejected due to activity deletion
 
   Scenario: Cancel Comment changes the Achievement as Rejected
@@ -470,7 +470,7 @@ Feature: Achievements
     Then the confirmation popup is not displayed
     And The comment 'comment to delete' is not displayed in Comments drawer of activity 'Activity with comment to cancel'
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
 
     Then Achievement for 'Comment activity in space' is rejected due to activity deletion
     And Achievement for 'Receive comment activity in space' is rejected due to activity deletion
@@ -540,11 +540,11 @@ Feature: Achievements
     And I wait for '1' seconds
     And I unlike the activity 'Activity to like + unlike'
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Like activity in space' is canceled
 
     When I login as 'seventhachievement' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Receive activity like in space' is canceled
 
   Scenario: Cancel Like Stream Comment changes the Achievement as Canceled
@@ -615,11 +615,11 @@ Feature: Achievements
     And I wait for '1' seconds
     And I unlike the activity comment 'comment to unlike'
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Like stream comment in space' is canceled
 
     When I login as 'seventhachievement' random user
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Receive Like on stream comment in space' is canceled
 
   Scenario: Cancel Space Join changes the Achievement as Canceled
@@ -658,13 +658,13 @@ Feature: Achievements
 
     When I login as 'eighthachievement' random user
     And I go to the random space
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
 
     Then Achievement for 'Space Join' is accepted
 
     And I go to spaces page
     And I search for the random space
     And I leave found space
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
 
     Then Achievement for 'Space Join' is canceled

--- a/src/test/resources/features/Gamification/Actions.feature
+++ b/src/test/resources/features/Gamification/Actions.feature
@@ -54,7 +54,7 @@ Feature: Actions
 
     Then The activity 'Challenge to announce' is displayed
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Challenge to announce' is pending
 
     When I go to 'programs' in site 'contribute'
@@ -185,7 +185,7 @@ Feature: Actions
     And I click on 'Announce an action from its activity' text
     Then '0' participants is displayed in action drawer
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Announce an action from its activity' is pending
     Then I click on 'Review' button
     Then I wait for application loading
@@ -353,7 +353,7 @@ Feature: Actions
     And I click on 'Cancel' button related to comment 'announcement11'
     And I click on Yes button
 
-    And I go to '/portal/contribute/contributions/achievements'
+    And I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Announce activity to delete' is canceled
 
   Scenario: Overview top challenge

--- a/src/test/resources/features/Gamification/Programs.feature
+++ b/src/test/resources/features/Gamification/Programs.feature
@@ -244,7 +244,7 @@ Feature: Programs
     And I open random program card
     And I announce challenge 'Internal users action' with message 'announcement3'
 
-    When I go to '/portal/contribute/contributions/achievements'
+    When I go to '/portal/contribute/contributions/achievements#yours'
     Then Achievement for 'Internal users action' is pending
 
     When I login as 'admin' random user


### PR DESCRIPTION
This change will allow a direct access to 'Yours' Tab to test on currently authenticated user achievements instead of getting 'Review' Tab.