### PR TITLE
fix: Stabilize Randomly failing Test Cases - MEED-7913

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
+++ b/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
@@ -202,11 +202,14 @@ public class BasePageImpl extends PageObject implements BasePage {
     return findByXPathOrCSS("(//*[contains(@class, 'v-dialog--active')]//*[contains(@class, 'close') or contains(@class, 'times')])[last()]");
   }
 
-  public void closeDrawerIfDisplayed() {
+  public boolean closeDrawerIfDisplayed() {
     if (openedDrawerElement().isCurrentlyVisible()) {
       closeDrawer();
       closeAlertIfOpened();
       waitForDrawerToClose();
+      return true;
+    } else {
+      return false;
     }
   }
 
@@ -508,18 +511,34 @@ public class BasePageImpl extends PageObject implements BasePage {
   }
 
   public void waitForDrawerToOpen() {
-    waitForDrawerToOpen(null, true);
+    waitForDrawerToOpen(null, true, false);
+  }
+
+  public void waitForDrawerToOpen(boolean throwException) {
+    waitForDrawerToOpen(null, true, throwException);
   }
 
   public void waitForDrawerToOpen(String drawerId, boolean withOverlay) {
+    waitForDrawerToOpen(null, true, false);
+  }
+
+  public void waitForDrawerToOpen(boolean withOverlay, boolean throwException) {
+    waitForDrawerToOpen(null, withOverlay, throwException);
+  }
+
+  public void waitForDrawerToOpen(String drawerId, boolean withOverlay, boolean throwException) {
     String drawerSelector = StringUtils.isBlank(drawerId) ? OPENED_DRAWER_CSS_SELECTOR : drawerId;
     try {
       findByXPathOrCSS(drawerSelector).waitUntilVisible();
       if (withOverlay) {
         findByXPathOrCSS(".v-overlay").waitUntilVisible();
       }
-    } catch (Exception e) {
-      LOGGER.debug("Overlay seems not displayed", e);
+    } catch (RuntimeException e) {
+      if (throwException) {
+        throw e;
+      } else {
+        LOGGER.debug("Overlay seems not displayed", e);
+      }
     }
   }
 

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -306,6 +306,8 @@ public class HomePage extends GenericPage {
   }
 
   public boolean isConnectionsBadgeWithNumberVisible(String number) {
+    retryOnCondition(() -> getConnectionsBadge().checkVisible(),
+                     () -> waitFor(1).seconds());
     return getConnectionsBadgeWithNumber(number).isVisible();
   }
 

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -340,6 +340,8 @@ public class HomePage extends GenericPage {
   }
 
   public boolean isSpacesBadgeWithNumberVisible(String number) {
+    retryOnCondition(() -> getSpacesBadge().checkVisible(),
+                     () -> waitFor(1).seconds());
     return getSpacesBadgeWithNumber(number).isVisible();
   }
 
@@ -720,6 +722,10 @@ public class HomePage extends GenericPage {
   private ElementFacade getRejectIconSpaceFromDrawer(String spaceName) {
     return findByXPathOrCSS(String.format("//aside[contains(@class,'spaceDrawer ')]//descendant::div[contains(text(),'%s')]//following::i[contains(@class,'mdi-close-circle')]",
                                           spaceName));
+  }
+
+  private ElementFacade getSpacesBadge() {
+    return findByXPathOrCSS("//div[contains(@class,'profileCard')]//*[contains(text(),'Spaces')]");
   }
 
   private ElementFacade getSpacesBadgeWithNumber(String number) {

--- a/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/TasksPage.java
@@ -226,10 +226,6 @@ public class TasksPage extends GenericPage {
     filterByTaskElement().assertVisible();
   }
 
-  public void checkDrawerDisplay() {
-    drawerTitleElement().assertVisible();
-  }
-
   public void checkFirstStatusColumn(String columnStatus) {
     assertEquals(firstStatusColumnElement().getText(), columnStatus);
   }
@@ -522,7 +518,6 @@ public class TasksPage extends GenericPage {
   }
 
   public void clickOnTaskThreeDotsOption() {
-
     taskThreeDotsOptionElement().click();
   }
 
@@ -936,9 +931,13 @@ public class TasksPage extends GenericPage {
   }
 
   public void openTaskDrawer(String taskName) {
-    closeDrawerIfDisplayed();
-    getTaskName(taskName).click();
-    waitForDrawerToOpen();
+    retryOnCondition(() -> {
+      if (closeDrawerIfDisplayed()) {
+        waitFor(200).milliseconds();
+      }
+      getTaskName(taskName).click();
+      waitForDrawerToOpen(true);
+    });
   }
 
   public void openTaskInTasksTab(String taskName) {
@@ -1322,10 +1321,6 @@ public class TasksPage extends GenericPage {
 
   private ElementFacade documentButtonElement() {
     return findByXPathOrCSS("//*[contains(@class ,'flex document-timeline-header ')]//button[contains(@class,'v-btn v-btn--flat')]");
-  }
-
-  private ElementFacade drawerTitleElement() {
-    return findByXPathOrCSS("//span[contains(text(),'Select Folder')]");
   }
 
   private ElementFacade editProjectButtonElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/TasksSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/TasksSteps.java
@@ -172,10 +172,6 @@ public class TasksSteps {
     tasksPage.checkDisplayOfFilterByTask();
   }
 
-  public void checkDrawerDisplay() {
-    tasksPage.checkDrawerDisplay();
-  }
-
   public void checkEditedProject(String projectName, String description) {
     tasksPage.checkUpdatedProject(projectName, description);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/TasksStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/TasksStepDefinition.java
@@ -275,11 +275,6 @@ public class TasksStepDefinition {
     tasksSteps.checkDisplayOfFilterByTask();
   }
 
-  @Then("^The drawer Select Folder should be displayed$")
-  public void checkDrawerDisplay() {
-    tasksSteps.checkDrawerDisplay();
-  }
-
   @And("^Status column '(.*)' is moved to the first position$")
   @Then("^Status column '(.*)' is displayed in the first position$")
   public void checkFirstStatusColumn(String columnStatus) {

--- a/src/test/resources/features/Social/AttachImage.feature
+++ b/src/test/resources/features/Social/AttachImage.feature
@@ -187,9 +187,9 @@ Feature: Attach images activities
     Then The action 'Announce an action with attached image' is displayed in program detail
     When I click on 'Activate the program' button
     Then Confirmation message is displayed 'Program activated'
-    When I close the notification
+    And I close the notification
 
-    When I go to Stream page
+    When I go to the random space
     Then The activity 'Announce an action with attached image' is not displayed
     
     When I go to 'programs' in site 'contribute'
@@ -201,13 +201,14 @@ Feature: Attach images activities
     And I enable rule publication
     And I set rule publication message 'Action publication message'
     And I attach an image to the program action
+    And I wait for '1' seconds
     And I click on 'Update' button in drawer
     Then Confirmation message is displayed 'Action has been successfully updated'
     And I close the notification
     Then The action 'Announce an action with attached image' is displayed in program detail
     And I wait for '1' seconds
 
-    When I go to Stream page
+    When I go to the random space
     Then The activity 'Announce an action with attached image' is displayed
     And The message 'Action publication message' is displayed
     And The attached images should be displayed in the published activity 'Announce an action with attached image'
@@ -216,6 +217,7 @@ Feature: Attach images activities
 
     When I click on 'Contribute' button in drawer
     And I attach an image to the announcement
+    And I wait for '1' seconds
     And I announce action with message 'announcement with attached image'
     And I close the notification
     Then The comment 'announcement with attached image' is displayed

--- a/src/test/resources/features/Social/ConnectionWidget.feature
+++ b/src/test/resources/features/Social/ConnectionWidget.feature
@@ -7,17 +7,12 @@ Feature: Connection widgets checking
   In order to validate the page
 
   Scenario: Connection widget accept and refuse user connections
-    Given I am authenticated as 'admin' if random users doesn't exists
-      | firstcommconn  |
-      | secondcommconn  |
-      | thirdcommconn  |
-      | fourthcommconn  |
-      | fifthcommconn  |
-    And I inject the firstcommconn random user if not existing, no wait
-    And I inject the secondcommconn random user if not existing, no wait
-    And I inject the thirdcommconn random user if not existing, no wait
-    And I inject the fourthcommconn random user if not existing, no wait
-    And I inject the fifthcommconn random user if not existing, no wait
+    Given I am authenticated as 'admin' random user
+    And I inject the firstcommconn random user, no wait
+    And I inject the secondcommconn random user, no wait
+    And I inject the thirdcommconn random user, no wait
+    And I inject the fourthcommconn random user, no wait
+    And I inject the fifthcommconn random user, no wait
     And I go to the fifthcommconn user profile
     And I connect to the user using the profile
     And I login as 'firstcommconn' random user

--- a/src/test/resources/features/Social/General.feature
+++ b/src/test/resources/features/Social/General.feature
@@ -18,7 +18,7 @@ Feature: General new composer
 
   # Bug detected and qualified as non-bloquer
   @ignored
-  Scenario: CAP109-[US-General-07]update posts - text update with normal Link (space case)
+  Scenario: Update posts - text update with normal Link (space case)
     Given I am authenticated as 'admin' random user
     And I go to the random space
     When I click on post in space

--- a/src/test/resources/features/Social/MeedsProfile.feature
+++ b/src/test/resources/features/Social/MeedsProfile.feature
@@ -13,7 +13,7 @@ Feature: Search for User Informations in Profile page
 
   # Needs bugs fixes after MIP#38 merge
   @ignored
-  Scenario: PROFILE-4 Contact information block_(01) : Add informations
+  Scenario: Add Contact information
     Given I am authenticated as 'admin' if random users doesn't exists
       | firstprofile  |
 
@@ -28,7 +28,7 @@ Feature: Search for User Informations in Profile page
 
   # Needs bugs fixes after MIP#38 merge
   @ignored
-  Scenario: PROFILE-4 Contact information block_(02) : Add informations
+  Scenario: Add Contact information
     Given I am authenticated as 'admin' if random users doesn't exists
       | secondprofile  |
 
@@ -46,7 +46,7 @@ Feature: Search for User Informations in Profile page
     And Updated Profile Contact instantMessaging is displayed
     And Updated Profile Contact Url is displayed
 
-  Scenario: PROFILE-5 Kudos block
+  Scenario: Kudos block
     Given I am authenticated as 'admin' if random users doesn't exists
       | fifthkudos  |
       | sixthkudos  |

--- a/src/test/resources/features/Social/SpacesWidget.feature
+++ b/src/test/resources/features/Social/SpacesWidget.feature
@@ -8,7 +8,7 @@ Feature: Spaces widget checking
   @smoke
   Scenario: Spaces requests to join
     Given I am authenticated as 'admin' random user
-    And I inject the eighteenth random user if not existing
+    And I inject the eighteenth random user
     And I create a random space with the eighteenth random user
     And I create a random space with the eighteenth random user
     And I create a random space with the eighteenth random user

--- a/src/test/resources/features/Tasks/Tasks.feature
+++ b/src/test/resources/features/Tasks/Tasks.feature
@@ -37,7 +37,7 @@ Feature: Tasks
     And The clear button is disappeared from Filter by task field
 
   @smoke
-  Scenario: (3 dots menu-Delete action) "Tasks TAB"
+  Scenario: Tasks TAB
     Given I am authenticated as 'admin' random user
 
     And I go to 'tasks' in site 'mycraft'


### PR DESCRIPTION
Prior to this change, some Test cases were failing due to the fact that its data is altered with the first tentative of execution, thus the Test conditions aren't independant from other execution tentatives. This change ensures to rely on new data each execution tentative to allow some randomly fails to happen without failing the Whole Test execution result.