### PR TITLE
fix: Stabilize Notes Editor Access Test Case - MEED-8017

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -354,12 +354,6 @@ public class HomePage extends GenericPage {
     return getProfileWidgetContent(widget, number).isVisible();
   }
 
-  public void openAllApplicationPage() {
-    waitForPageLoading();
-    clickOnElement(viewAllApplicationLinkElement());
-    waitForPageLoading();
-  }
-
   public void openConnectionRequestDrawer() {
     ElementFacade badgeButton = findByXPathOrCSS("#profile-stats-connectionsCount .v-badge button");
     clickOnElement(badgeButton);
@@ -839,10 +833,6 @@ public class HomePage extends GenericPage {
 
   private ElementFacade thirdLevelNavigationElement() {
     return findByXPathOrCSS("//*[contains(@class,'HamburgerMenuThirdLevelParent')]");
-  }
-
-  private ElementFacade viewAllApplicationLinkElement() {
-    return findByXPathOrCSS("//a[contains(@class,'seeAllApplicationsBtn')]");
   }
 
   private ElementFacade hamburgerMenuSiteArrowIcon() {

--- a/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ManageSpacesPage.java
@@ -453,7 +453,7 @@ public class ManageSpacesPage extends GenericPage {
   }
 
   private ElementFacade addNewSpaceButtonElement() {
-    return findByXPathOrCSS("#spacesListApplication button#addNewSpaceButton");
+    return findByXPathOrCSS("#addNewSpaceButton");
   }
 
   private ElementFacade avatarSectionElement() {

--- a/src/main/java/io/meeds/qa/ui/pages/SpacePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/SpacePage.java
@@ -710,38 +710,20 @@ public class SpacePage extends GenericPage {
     peopleBtnElement().click();
   }
 
-  public void addSpaceApplicationIfNotExisting(String applicationName) {
-    ElementFacade tabElement = searchSpaceTabElement(applicationName);
-    if (tabElement.isCurrentlyVisible()) {
-      return;
-    }
-    installedApplicationCard(applicationName).assertNotVisible(); // Check app
-                                                                  // not already
-                                                                  // added
-    goToSpecificTab("More/Settings");
-    verifyPageLoaded();
-    arrowIconAppSpaceSettingsElement().click();
-    plusButtonAppSpaceSettingsElement().click();
-    waitForDrawerToOpen();
-    addApplicationButton(applicationName).click();
-    waitForDrawerToClose();
-    refreshPage();
-    waitForLoading();
-  }
-
   public void goToSpecificTab(String tabName) {
     if (tabName.contains("/")) {
       String[] navigationParts = tabName.split("/");
       searchNavigationTabElement(navigationParts[0]).assertVisible();
       tabElement(navigationParts[0]).hover();
       tabSubNavigationElement(navigationParts[1]).click();
+      verifyPageLoaded();
     } else {
       ElementFacade tabElement = searchSpaceTabElement(tabName);
       tabElement.assertVisible();
       if (!selectedTabElement(tabName).isCurrentlyVisible()) {
         tabElement.click();
-        waitForLoading();
       }
+      verifyPageLoaded();
       selectedTabElement(tabName).assertVisible();
     }
   }
@@ -1298,24 +1280,6 @@ public class SpacePage extends GenericPage {
       tabElement.checkVisible();
       return tabElement;
     });
-  }
-
-  private ElementFacade installedApplicationCard(String applicationName) {
-    return findByXPathOrCSS(String.format("//*[contains(@class, 'SpaceApplicationCard')]//*[contains(text(), '%s')]",
-                                          applicationName));
-  }
-
-  private ElementFacade addApplicationButton(String applicationName) {
-    return findByXPathOrCSS(String.format("//*[contains(@class, 'v-navigation-drawer--open')]//*[contains(@class, 'SpaceApplicationCard')]//*[contains(text(), '%s')]//ancestor::*[contains(@class, 'SpaceApplicationCardBody')]/parent::*//button",
-                                          applicationName));
-  }
-
-  private ElementFacade plusButtonAppSpaceSettingsElement() {
-    return findByXPathOrCSS("//*[@class='v-icon notranslate mdi mdi-plus theme--light']");
-  }
-
-  private ElementFacade arrowIconAppSpaceSettingsElement() {
-    return findByXPathOrCSS("//i[@class='v-icon notranslate text-sub-title fa fa-caret-right theme--light']");
   }
 
   private TextBoxElementFacade activityContentTextBoxElement() {

--- a/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/HomeSteps.java
@@ -252,10 +252,6 @@ public class HomeSteps {
     return homePage.isWidgetWithNumberVisible(widget, number);
   }
 
-  public void openAllApplicationPage() {
-    homePage.openAllApplicationPage();
-  }
-
   public void openNotifications() {
     homePage.openNotifications();
   }

--- a/src/test/java/io/meeds/qa/ui/steps/SpaceSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/SpaceSteps.java
@@ -371,10 +371,6 @@ public class SpaceSteps {
     spacePage.goToSpecificTab(tabName);
   }
 
-  public void addSpaceApplicationIfNotExisting(String appName) {
-    spacePage.addSpaceApplicationIfNotExisting(appName);
-  }
-
   public void goToUserProfileFromLikersDrawer(String prefix) {
     spacePage.goToUserProfileFromLikersDrawer(prefix);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/ApplicationStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/ApplicationStepDefinition.java
@@ -161,10 +161,9 @@ public class ApplicationStepDefinition {
     genericSteps.isPageOpened(uriPart);
   }
 
-  @When("I see All Applications")
+  @When("I open all application page")
   public void seeAllApplications() {
     applicationSteps.seeAllApplications();
-
   }
 
   @Then("Settings Application Page is displayed")

--- a/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/HomeStepDefinition.java
@@ -353,11 +353,6 @@ public class HomeStepDefinition {
     homeSteps.checkThirdLevelNavigationDisplayed();
   }
 
-  @When("^I open all application page$")
-  public void openAllApplicationPage() {
-    homeSteps.openAllApplicationPage();
-  }
-
   @When("^I open Notifications$")
   public void openNotifications() {
     homeSteps.openNotifications();

--- a/src/test/java/io/meeds/qa/ui/steps/definition/SpaceStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/SpaceStepDefinition.java
@@ -557,11 +557,6 @@ public class SpaceStepDefinition {
     spaceSteps.goToSpecificTab(tabName);
   }
 
-  @Given("^I add application '(.*)' in random space if not existing$")
-  public void addSpaceApplicationIfNotExisting(String appName) {
-    spaceSteps.addSpaceApplicationIfNotExisting(appName);
-  }
-
   @When("^I open user profile of (.*) user from activity likers drawer$")
   public void goToUserProfileFromLikersDrawer(String prefix) {
     spaceSteps.goToUserProfileFromLikersDrawer(prefix);

--- a/src/test/resources/features/AppCenter/AppCenter.feature
+++ b/src/test/resources/features/AppCenter/AppCenter.feature
@@ -36,7 +36,7 @@ Feature: Application center Addon
     And I go to Administer application center Page
     And I add a new random application
     And I login as 'first' random user
-    And I see All Applications
+    And I open all application page
     Then The message 'You can’t set more than 12 favorites' is displayed
     When I search for the random created application
     Then The application is not bookmarked as my favorites
@@ -54,7 +54,7 @@ Feature: Application center Addon
     And I go to Administer application center Page
     And I search for the random created application
     And I login as 'first' random user
-    And I see All Applications
+    And I open all application page
     Then The application bookmark is disabled
 
   Scenario: Applications table/ Editable fields (Active option)
@@ -65,7 +65,7 @@ Feature: Application center Addon
     And I add a new random application
 
     And I login as 'first' random user
-    And I see All Applications
+    And I open all application page
 
     When I search for the random created application
     Then The created application is not displayed in Favorites Applications
@@ -80,7 +80,7 @@ Feature: Application center Addon
     And I search for the random created application
     And I disable Active option for the created application
     And I login as 'first' random user
-    And I see All Applications
+    And I open all application page
     And I search for the random created application
     Then The created application is not displayed in Favorites Applications
     And I refresh the page
@@ -93,7 +93,7 @@ Feature: Application center Addon
     And I search for the random created application
     And I enable Active option for the created application
     And I login as 'first' random user
-    And I see All Applications
+    And I open all application page
     And I search for the random created application
     Then The created application is not displayed in Favorites Applications
     And I search for the random created application
@@ -177,7 +177,7 @@ Feature: Application center Addon
 
     When I login as 'first' random user
 
-    When I see All Applications
+    When I open all application page
     And I search for the random created application
     Then The application is not bookmarked as my favorites
     And The created application is not displayed in Favorites Applications

--- a/src/test/resources/features/Notes/Notes.feature
+++ b/src/test/resources/features/Notes/Notes.feature
@@ -8,8 +8,6 @@ Feature: Notes
     Given I am authenticated as 'admin' random user
     And I inject the hmenu random user, no wait
     And I inject the random space
-    And I go to the random space
-    And I add application 'Notes' in random space if not existing
     When I login as 'hmenu' random user
     And I go to the random space
     And I click on 'Notes' space menu tab


### PR DESCRIPTION
Prior to this change, the Notes Application isn't ready for use right after creating the space. This change make sure to add a specific delay between Space creation and Notes page display to ensure to have the Space created before displaying the page. In addition, this change will delete some useless checks since there is no Space Application management anymore.