### PR TITLE
fix: Fix Random Fail Re-execution fail - MEED-8127

### DIFF
--- a/src/test/resources/features/Gamification/Actions.feature
+++ b/src/test/resources/features/Gamification/Actions.feature
@@ -148,7 +148,7 @@ Feature: Actions
     Then Confirmation message is displayed 'Program activated'
     When I close the notification
 
-    When I go to Stream page
+    When I go to the random space
     Then The activity 'Announce an action from its activity' is not displayed
 
     When I go to 'programs' in site 'contribute'
@@ -163,7 +163,7 @@ Feature: Actions
     Then Confirmation message is displayed 'Action has been successfully updated'
     When I close the notification
 
-    When I go to Stream page
+    When I go to the random space
     Then The activity 'Announce an action from its activity' is displayed
     And The message 'Action publication message' is displayed
 
@@ -173,7 +173,9 @@ Feature: Actions
     When I click on 'Contribute' button in drawer
     And I announce action with message 'announcement12'
     And I close the notification
-    Then The comment 'announcement12' is displayed
+    And I go to the random space
+    Then The activity 'Announce an action from its activity' is displayed
+    And The comment 'announcement12' is displayed in Comments drawer of activity 'Announce an action from its activity'
 
     When I click on 'Announce an action from its activity' text
     Then '0' participants is displayed in action drawer

--- a/src/test/resources/features/Kudos/kudos.feature
+++ b/src/test/resources/features/Kudos/kudos.feature
@@ -162,6 +162,7 @@ Feature: Kudos
     When I login as 'cancelfirst' random user
     And I go to Stream page
     And I cancel the sent kudos activity 'Message for kudos - Kudos to cancel'
+    And I go to Stream page
     Then the activity 'Message for kudos - Kudos to cancel' is no more displayed in the activity stream
 
     When I go to My Profile page

--- a/src/test/resources/features/Social/AttachImage.feature
+++ b/src/test/resources/features/Social/AttachImage.feature
@@ -201,7 +201,7 @@ Feature: Attach images activities
     And I enable rule publication
     And I set rule publication message 'Action publication message'
     And I attach an image to the program action
-    And I wait for '1' seconds
+    And I wait for '3' seconds
     And I click on 'Update' button in drawer
     Then Confirmation message is displayed 'Action has been successfully updated'
     And I close the notification


### PR DESCRIPTION
The Test case 'Announce an action from its activity' randomly fails even when re-executed. It should be independant from previous execution result when re-executed. This change ensures to test on newly injected Space Stream rather than general stream.