### PR TITLE
fix: Fix Closing Sidebar Drawer - Meeds-io/MIPs#175

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
+++ b/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
@@ -684,6 +684,10 @@ public class BasePageImpl extends PageObject implements BasePage {
     waitForProgressBar();
   }
 
+  public void pressEscape() {
+    findByXPathOrCSS("//body").sendKeys(Keys.ESCAPE);
+  }
+
   private void closeDrawer() {
     closeDrawer(MAX_WAIT_RETRIES);
   }
@@ -701,10 +705,6 @@ public class BasePageImpl extends PageObject implements BasePage {
     } else {
       pressEscape();
     }
-  }
-
-  private void pressEscape() {
-    findByXPathOrCSS("//body").sendKeys(Keys.ESCAPE);
   }
 
   private WebElementFacade getWebElementFacadeByXPathOrCSS(String xpathOrCss) {

--- a/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/GenericPage.java
@@ -209,7 +209,8 @@ public class GenericPage extends BasePageImpl {
   }
 
   private ElementFacade messageElementInPage(String message) {
-    return findByXPathOrCSS(String.format("//*[@id = 'UIPage']//*[contains(text(), '%s') and not (@role)]", message));
+    return findByXPathOrCSS(String.format("//*[@id = 'UIPage' or contains(@class, 'layout-page-parent')]//*[contains(text(), '%s') and not (@role)]",
+                                          message));
   }
 
   private ElementFacade translationButton(int index) {

--- a/src/main/java/io/meeds/qa/ui/pages/HomePage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/HomePage.java
@@ -492,7 +492,17 @@ public class HomePage extends GenericPage {
   }
 
   public void clickOutsideHamburgerMenu() {
-    getDrawerOverlay().click();
+    ElementFacade drawerOverlay = getDrawerOverlay();
+    if (drawerOverlay.isCurrentlyVisible()) {
+      drawerOverlay.click();
+    } else {
+      drawerOverlay = getHamburgerMenuDrawerOverlay();
+      if (drawerOverlay.isCurrentlyVisible()) {
+        drawerOverlay.click();
+      } else {
+        pressEscape();
+      }
+    }
   }
 
   public void closeHamburgerMenu() {
@@ -684,6 +694,10 @@ public class HomePage extends GenericPage {
 
   private ElementFacade getDrawerOverlay() {
     return findByXPathOrCSS("#drawers-overlay .v-overlay--active");
+  }
+
+  private ElementFacade getHamburgerMenuDrawerOverlay() {
+    return findByXPathOrCSS("#HamburgerNavigationMenu .v-overlay--active");
   }
 
   private ElementFacade getSiteBody() {

--- a/src/main/java/io/meeds/qa/ui/pages/UnifiedSearchPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/UnifiedSearchPage.java
@@ -154,7 +154,7 @@ public class UnifiedSearchPage extends GenericPage {
   }
 
   private TextBoxElementFacade searchInputElement() {
-    return findTextBoxByXPathOrCSS("//*[@id='SearchApplication']//input[@id = 'searchInput']");
+    return findTextBoxByXPathOrCSS("//*[@id='searchDialog']//input[@id='searchInput']");
   }
 
   private ElementFacade shipFormAllElement() {

--- a/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
+++ b/src/test/java/io/meeds/qa/ui/hook/TestInitHook.java
@@ -207,6 +207,7 @@ public class TestInitHook {
       throw new IllegalStateException("Couldn't login with admin");
     }
     genericSteps.disableTermsAndConditions();
+    genericSteps.goToPage("/");
   }
 
   private void loginAsRandomAdmin() {

--- a/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
@@ -265,12 +265,7 @@ public class GenericSteps {
   }
 
   public void disableTermsAndConditions() {
-    WebDriverWait wait = new WebDriverWait(Serenity.getDriver(),
-                                           Duration.ofSeconds(10),
-                                           Duration.ofMillis(SHORT_WAIT_DURATION_MILLIS));
-    wait.until(driver -> ((JavascriptExecutor) driver).executeAsyncScript(DISABLE_TERMS_SCRIPT)
-                                                      .toString()
-                                                      .equals("true"));
+    ((JavascriptExecutor) Serenity.getDriver()).executeAsyncScript(DISABLE_TERMS_SCRIPT);
   }
 
   public void goToPage(String link) {


### PR DESCRIPTION
Prior to this change, the Sidebar drawer overlay was relying on generic overlay only. With Site Layout changes, the overlay can be provided from Sidebar App too. This change is changing the algorithm for searching for opened overlay to consider both cases.