### PR TITLE
feat: Enhance User Language Setting Test - MEED-8665 - Meeds-io/meeds#3159

### DIFF
--- a/src/test/resources/features/Social/MeedsSettings.feature
+++ b/src/test/resources/features/Social/MeedsSettings.feature
@@ -12,21 +12,21 @@ Feature: Edit sections in Settings page
     And I go to Settings page
     Then Settings Page Is Opened
 
-    When I click on Edit language and I change it 'French'
+    When I click on Edit language and I change it 'français'
     And I cancel editing language
 
     Then Language 'English' is displayed
 
-    When I click on Edit language and I change it 'French'
+    When I click on Edit language and I change it 'français'
     And I accept editing language
 
-    Then Language 'French' is displayed
+    Then Language 'français' is displayed
 
     When I click on Edit language and I change it 'English'
     And I accept editing language
 
     When I refresh the page
-    Then Language 'English / English' is displayed
+    Then Language 'English' is displayed
 
   Scenario: Add the home icon for Homepage default view
     Given I am authenticated as 'admin' if random users doesn't exists


### PR DESCRIPTION
Prior to this change, when the user switches to FR language, then the languages list drawer updates the languages list to use FR Lang rather than EN. This change will adapt the Test Case to allow display the locale using user language.