### PR TITLE
fix: Adapt Programs Tests after removing go back button - MEED-9582 - Meeds-io/meeds#3419

### DIFF
--- a/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
+++ b/src/main/java/io/meeds/qa/ui/pages/BasePageImpl.java
@@ -222,10 +222,6 @@ public class BasePageImpl extends PageObject implements BasePage {
     goBackButton().click();
   }
 
-  public void clickOnGoBackInDrawer() {
-    goBackButtonInDrawer().click();
-  }
-
   public void clickButton(String buttonText, int index) {
     ElementFacade button = getButton(buttonText, index);
     button.checkVisible();
@@ -717,10 +713,6 @@ public class BasePageImpl extends PageObject implements BasePage {
 
   private ElementFacade goBackButton() {
     return findByXPathOrCSS("#UIPage .fa-arrow-left");
-  }
-
-  private ElementFacade goBackButtonInDrawer() {
-    return findByXPathOrCSS(OPENED_DRAWER_CSS_SELECTOR + " .fa-arrow-left");
   }
 
   private void waitOverlayToClose() {

--- a/src/main/java/io/meeds/qa/ui/pages/ProgramsPage.java
+++ b/src/main/java/io/meeds/qa/ui/pages/ProgramsPage.java
@@ -70,10 +70,6 @@ public class ProgramsPage extends GenericPage {
     programStatusSwitcher().assertNotVisible();
   }
 
-  public void goBackUsingProgramTitle(String programName) {
-    getProgramDetailTitle(programName).click();
-  }
-
   public void addSpaceAudience(String randomSpaceName) {
     mentionInField(audienceSpaceFieldElement(), randomSpaceName, 5);
   }
@@ -405,11 +401,6 @@ public class ProgramsPage extends GenericPage {
 
   private ElementFacade getProgramCardTitle(String title) {
     return findByXPathOrCSS(String.format("//*[contains(text(),'%s')]//ancestor::*[contains(@class,'engagement-center-card')]",
-                                          title));
-  }
-
-  private ElementFacade getProgramDetailTitle(String title) {
-    return findByXPathOrCSS(String.format("//*[@id='engagementCenterProgramDetail']//*[contains(@class,'v-card')]//*[contains(text(),'%s')]",
                                           title));
   }
 

--- a/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/GenericSteps.java
@@ -195,10 +195,6 @@ public class GenericSteps {
     genericPage.clickOnGoBack();
   }
 
-  public void clickOnGoBackInDrawer() {
-    genericPage.clickOnGoBackInDrawer();
-  }
-
   public boolean containsContent(String content) {
     return genericPage.containsContent(content);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/ProgramsSteps.java
+++ b/src/test/java/io/meeds/qa/ui/steps/ProgramsSteps.java
@@ -42,10 +42,6 @@ public class ProgramsSteps {
     programsPage.checkProgramStatusSwitchNotDisplayed();
   }
 
-  public void goBackUsingProgramTitle(String programName) {
-    programsPage.goBackUsingProgramTitle(programName);
-  }
-
   public void enterProgramDescription(String programDescription) {
     programsPage.enterProgramDescription(programDescription);
   }

--- a/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/GenericStepDefinitions.java
@@ -261,11 +261,6 @@ public class GenericStepDefinitions {
     genericSteps.clickOnGoBack();
   }
 
-  @Then("I click on go back button in drawer")
-  public void clickOnGoBackInDrawer() {
-    genericSteps.clickOnGoBackInDrawer();
-  }
-
   @When("I wait '{int}' seconds")
   @And("I wait for '{int}' seconds")
   public void waitInSeconds(int seconds) {

--- a/src/test/java/io/meeds/qa/ui/steps/definition/ProgramsStepDefinition.java
+++ b/src/test/java/io/meeds/qa/ui/steps/definition/ProgramsStepDefinition.java
@@ -98,12 +98,6 @@ public class ProgramsStepDefinition {
     programsSteps.checkProgramCoverIsDefaultInDetail();
   }
 
-  @Then("I click on program title to go back")
-  public void goBackUsingProgramTitle() {
-    String programName = Serenity.sessionVariableCalled("programName");
-    programsSteps.goBackUsingProgramTitle(programName);
-  }
-
   @And("^I add program with random description$")
   @And("I enter a random description for program")
   public void enterProgramRandomDescription() {

--- a/src/test/resources/features/Gamification/Programs.feature
+++ b/src/test/resources/features/Gamification/Programs.feature
@@ -46,10 +46,7 @@ Feature: Programs
     Then The program status switch is not displayed 
 
     When I close the opened drawer
-    And I click on program title to go back
-    Then The program card should not be displayed
-
-    When I filter programs by value 'ENABLED'
+    And I go to Programs page
     Then The program card should not be displayed
 
     When I filter programs by value 'DISABLED'
@@ -352,7 +349,7 @@ Feature: Programs
     Then Confirmation message is displayed 'New campaign created successfully'
 
     When I close the notification
-    And I click on go back button in drawer
+    And I go to Programs page
     And I filter programs by value 'DISABLED'
     Then The program title should be displayed on the card
 


### PR DESCRIPTION
This change will fix automatic tests after having removed the 'Go Back' button and replaced by a drawer in expanded view.

Resolves Meeds-io/meeds#3419